### PR TITLE
Typos in the bit plane filter.

### DIFF
--- a/Source/Resource/Help/Playback Filters/Playback Filters.html
+++ b/Source/Resource/Help/Playback Filters/Playback Filters.html
@@ -99,7 +99,7 @@
             Bit Plane
         </h2>
         <p>
-            This filter selects the bit position of each plane for display. Selecting 'None' for a plane will replace all values with 0x80 (middle gray for Y and no color for U or V). Selecting 'All' will send the display plane as is. Selecting 'Bit [1-8]' will display only that specific bit position of each pixel of the plane. For the Y plane a pixel will display as black is that bit is '0' or white is that bit is '1'. For U a pixel will be yellow-green if '0' purple if '1'. For V a pixel will be green for '0' and red for '1'.<br />
+            This filter selects the bit position of each plane for display. Selecting 'None' for a plane will replace all values with 0x80 (middle gray for Y and no color for U or V). Selecting 'All' will send the display plane as is. Selecting 'Bit [1-8]' will display only that specific bit position of each pixel of the plane. For the Y plane a pixel will display as black if that bit is '0' or white if that bit is '1'. For U a pixel will be yellow-green if '0' purple if '1'. For V a pixel will be green for '0' and red for '1'.<br />
             Generally lossy video codecs will show blocky structured patterns at higher numbered bit positions. See the <a href="https://en.wikipedia.org/wiki/Bit_plane">bit plane article</a> in Wikipedia for more information about the application of bit plane filtering.<br />
             <img src="1A_seattle_parade_transfer_a_messedup-1.jpg" alt="Bit Plane" /><br />
             <br />


### PR DESCRIPTION
Simple typo, "is" instead of "if"