### PR TITLE
Add initial project file to build with homebrew environment

### DIFF
--- a/Project/Homebrew/README.md
+++ b/Project/Homebrew/README.md
@@ -1,0 +1,22 @@
+Building
+--------
+
+Install ffmpeg, freetype2, qt5
+
+# brew install ffmpeg freetype2 qt5
+
+Uninstall qwt if already installed and reinstall from provided formula (this might
+require not having a homebrew installation of qt (aka qt4):
+
+# brew uninstall qwt
+# brew install ./qwt
+
+Build the main application
+
+# qmake
+# make
+
+Caveats
+-------
+
+Building qwt with qt4 installed was not tested and might not work.

--- a/Project/Homebrew/README.md
+++ b/Project/Homebrew/README.md
@@ -3,18 +3,18 @@ Building
 
 Install ffmpeg, freetype2, qt5
 
-  $ brew install ffmpeg freetype2 qt5
+    $ brew install ffmpeg freetype2 qt5
 
 Uninstall qwt if already installed and reinstall from provided formula (this might
 require not having a homebrew installation of qt (aka qt4):
 
-  $ brew uninstall qwt
-  $ brew install ./qwt
+    $ brew uninstall qwt
+    $ brew install ./qwt
 
 Build the main application
 
-  $ qmake
-  $ make
+    $ qmake
+    $ make
 
 Caveats
 -------

--- a/Project/Homebrew/README.md
+++ b/Project/Homebrew/README.md
@@ -3,18 +3,18 @@ Building
 
 Install ffmpeg, freetype2, qt5
 
-# brew install ffmpeg freetype2 qt5
+  $ brew install ffmpeg freetype2 qt5
 
 Uninstall qwt if already installed and reinstall from provided formula (this might
 require not having a homebrew installation of qt (aka qt4):
 
-# brew uninstall qwt
-# brew install ./qwt
+  $ brew uninstall qwt
+  $ brew install ./qwt
 
 Build the main application
 
-# qmake
-# make
+  $ qmake
+  $ make
 
 Caveats
 -------

--- a/Project/Homebrew/qctools.pro
+++ b/Project/Homebrew/qctools.pro
@@ -1,0 +1,93 @@
+QT += core gui widgets svg printsupport
+
+TARGET = QCTools
+TEMPLATE = app
+
+QT_CONFIG -= no-pkg-config
+
+include ( $$system(brew --prefix qwt)/features/qwt.prf )
+
+CONFIG += qt qwt release no_keywords
+
+PKGCONFIG += libavdevice libavcodec libavfilter libavformat libpostproc
+PKGCONFIG += libswresample libswscale libavcodec libavutil freetype2
+
+CONFIG += link_pkgconfig
+
+HEADERS = \
+    ../../Source/Core/AudioCore.h \
+    ../../Source/Core/AudioStats.h \
+    ../../Source/Core/CommonStats.h \
+    ../../Source/Core/Core.h \
+    ../../Source/Core/BlackmagicDeckLink.h \
+    ../../Source/Core/BlackmagicDeckLink_Glue.h \
+    ../../Source/Core/FFmpeg_Glue.h \
+    ../../Source/Core/VideoCore.h \
+    ../../Source/Core/VideoStats.h \
+    ../../Source/Core/Timecode.h \
+    ../../Source/GUI/blackmagicdecklink_userinput.h \
+    ../../Source/GUI/BigDisplay.h \
+    ../../Source/GUI/Control.h \
+    ../../Source/GUI/FileInformation.h \
+    ../../Source/GUI/FilesList.h \
+    ../../Source/GUI/Help.h \
+    ../../Source/GUI/Info.h \
+    ../../Source/GUI/mainwindow.h \
+    ../../Source/GUI/preferences.h \
+    ../../Source/GUI/Plot.h \
+    ../../Source/GUI/Plots.h \
+    ../../Source/GUI/PlotLegend.h \
+    ../../Source/GUI/PlotScaleWidget.h \
+    ../../Source/GUI/TinyDisplay.h \
+    ../../Source/ThirdParty/tinyxml2/tinyxml2.h
+
+SOURCES = \
+    ../../Source/Core/AudioCore.cpp \
+    ../../Source/Core/AudioStats.cpp \
+    ../../Source/Core/CommonStats.cpp \
+    ../../Source/Core/Core.cpp \
+    ../../Source/Core/BlackmagicDeckLink.cpp \
+    ../../Source/Core/BlackmagicDeckLink_Glue.cpp \
+    ../../Source/Core/FFmpeg_Glue.cpp \
+    ../../Source/Core/VideoCore.cpp \
+    ../../Source/Core/VideoStats.cpp \
+    ../../Source/Core/Timecode.cpp \
+    ../../Source/GUI/blackmagicdecklink_userinput.cpp \
+    ../../Source/GUI/BigDisplay.cpp \
+    ../../Source/GUI/Control.cpp \
+    ../../Source/GUI/FileInformation.cpp \
+    ../../Source/GUI/FilesList.cpp \
+    ../../Source/GUI/Help.cpp \
+    ../../Source/GUI/Info.cpp \
+    ../../Source/GUI/main.cpp \
+    ../../Source/GUI/mainwindow.cpp \
+    ../../Source/GUI/mainwindow_Callbacks.cpp \
+    ../../Source/GUI/mainwindow_More.cpp \
+    ../../Source/GUI/mainwindow_Ui.cpp \
+    ../../Source/GUI/Plot.cpp \
+    ../../Source/GUI/Plots.cpp \
+    ../../Source/GUI/PlotLegend.cpp \
+    ../../Source/GUI/PlotScaleWidget.cpp \
+    ../../Source/GUI/preferences.cpp \
+    ../../Source/GUI/TinyDisplay.cpp \
+    ../../Source/ThirdParty/tinyxml2/tinyxml2.cpp
+
+FORMS += \
+    ../../Source/GUI/mainwindow.ui \
+    ../../Source/GUI/preferences.ui \
+    ../../Source/GUI/blackmagicdecklink_userinput.ui
+
+RESOURCES += \
+    ../../Source/Resource/Resources.qrc
+
+INCLUDEPATH += $$PWD/../../Source
+INCLUDEPATH += $$PWD/../../Source/ThirdParty/tinyxml2
+
+LIBS      += -lz
+LIBS      += -lbz2
+
+!macx:LIBS      += -ldl -lrt
+
+macx:ICON = ../../Source/Resource/Logo.icns
+macx:QMAKE_LFLAGS += -framework CoreFoundation -framework CoreVideo -framework VideoDecodeAcceleration
+macx:LIBS += -liconv

--- a/Project/Homebrew/qctools.pro
+++ b/Project/Homebrew/qctools.pro
@@ -14,6 +14,8 @@ PKGCONFIG += libswresample libswscale libavcodec libavutil freetype2
 
 CONFIG += link_pkgconfig
 
+QMAKE_CXXFLAGS += -DBLACKMAGICDECKLINK_NO -DWITH_SYSTEM_FFMPEG=1
+
 HEADERS = \
     ../../Source/Core/AudioCore.h \
     ../../Source/Core/AudioStats.h \

--- a/Project/Homebrew/qctools.pro
+++ b/Project/Homebrew/qctools.pro
@@ -5,7 +5,7 @@ TEMPLATE = app
 
 QT_CONFIG -= no-pkg-config
 
-include ( $$system(brew --prefix qwt)/features/qwt.prf )
+include ( $$system(brew --prefix qwt-qt5)/features/qwt.prf )
 
 CONFIG += qt qwt release no_keywords
 

--- a/Project/Homebrew/qctools.pro
+++ b/Project/Homebrew/qctools.pro
@@ -3,6 +3,8 @@ QT += core gui widgets svg printsupport
 TARGET = QCTools
 TEMPLATE = app
 
+QMAKE_TARGET_BUNDLE_PREFIX = org.bavc
+
 QT_CONFIG -= no-pkg-config
 
 include ( $$system(brew --prefix qwt-qt5)/features/qwt.prf )

--- a/Project/Homebrew/qwt-qt5.rb
+++ b/Project/Homebrew/qwt-qt5.rb
@@ -1,8 +1,10 @@
-class Qwt < Formula
-  desc "Qt Widgets for Technical Applications"
+class QwtQt5 < Formula
+  desc "Qt Widgets for Technical Applications (for Qt5)"
   homepage "http://qwt.sourceforge.net/"
   url "https://downloads.sourceforge.net/project/qwt/qwt/6.1.2/qwt-6.1.2.tar.bz2"
   sha256 "2b08f18d1d3970e7c3c6096d850f17aea6b54459389731d3ce715d193e243d0c"
+
+  keg_only "Qwt for Qt 5 conflicts with Qwt for Qt 4"
 
   option "with-qwtmathml", "Build the qwtmathml library"
   option "without-plugin", "Skip building the Qt Designer plugin"
@@ -17,16 +19,26 @@ class Qwt < Formula
     inreplace "qwtconfig.pri" do |s|
       s.gsub! /^\s*QWT_INSTALL_PREFIX\s*=(.*)$/, "QWT_INSTALL_PREFIX=#{prefix}"
       s.sub! /\+(=\s*QwtDesigner)/, "-\\1" if build.without? "plugin"
+
+      # Install Qt plugin in `lib/qt4/plugins/designer`, not `plugins/designer`.
+      s.sub! %r{(= \$\$\{QWT_INSTALL_PREFIX\})/(plugins/designer)$},
+             "\\1/lib/qt5/\\2"
     end
 
     args = ["-config", "release"]
+
+    if ENV.compiler == :clang && MacOS.version >= :mavericks
+      args << "-spec" << "macx-clang"
+    else
+      args << "-spec" << "macx-g++"
+    end
 
     if build.with? "qwtmathml"
       args << "QWT_CONFIG+=QwtMathML"
       prefix.install "textengines/mathml/qtmmlwidget-license"
     end
 
-    system "qmake", *args
+    system "#{Formula["qt5"].bin}/qmake", *args
     system "make"
     system "make", "install"
   end

--- a/Project/Homebrew/qwt.rb
+++ b/Project/Homebrew/qwt.rb
@@ -1,0 +1,70 @@
+class Qwt < Formula
+  desc "Qt Widgets for Technical Applications"
+  homepage "http://qwt.sourceforge.net/"
+  url "https://downloads.sourceforge.net/project/qwt/qwt/6.1.2/qwt-6.1.2.tar.bz2"
+  sha256 "2b08f18d1d3970e7c3c6096d850f17aea6b54459389731d3ce715d193e243d0c"
+
+  option "with-qwtmathml", "Build the qwtmathml library"
+  option "without-plugin", "Skip building the Qt Designer plugin"
+
+  depends_on "qt5"
+
+  # Update designer plugin linking back to qwt framework/lib after install
+  # See: https://sourceforge.net/p/qwt/patches/45/
+  patch :DATA
+
+  def install
+    inreplace "qwtconfig.pri" do |s|
+      s.gsub! /^\s*QWT_INSTALL_PREFIX\s*=(.*)$/, "QWT_INSTALL_PREFIX=#{prefix}"
+      s.sub! /\+(=\s*QwtDesigner)/, "-\\1" if build.without? "plugin"
+    end
+
+    args = ["-config", "release"]
+
+    if build.with? "qwtmathml"
+      args << "QWT_CONFIG+=QwtMathML"
+      prefix.install "textengines/mathml/qtmmlwidget-license"
+    end
+
+    system "qmake", *args
+    system "make"
+    system "make", "install"
+  end
+
+  def caveats
+    s = ""
+
+    if build.with? "qwtmathml"
+      s += <<-EOS.undent
+        The qwtmathml library contains code of the MML Widget from the Qt solutions package.
+        Beside the Qwt license you also have to take care of its license:
+        #{opt_prefix}/qtmmlwidget-license
+      EOS
+    end
+
+    s
+  end
+end
+
+__END__
+diff --git a/designer/designer.pro b/designer/designer.pro
+index c269e9d..c2e07ae 100644
+--- a/designer/designer.pro
++++ b/designer/designer.pro
+@@ -126,6 +126,16 @@ contains(QWT_CONFIG, QwtDesigner) {
+
+     target.path = $${QWT_INSTALL_PLUGINS}
+     INSTALLS += target
++
++    macx {
++        contains(QWT_CONFIG, QwtFramework) {
++            QWT_LIB = qwt.framework/Versions/$${QWT_VER_MAJ}/qwt
++        }
++        else {
++            QWT_LIB = libqwt.$${QWT_VER_MAJ}.dylib
++        }
++        QMAKE_POST_LINK = install_name_tool -change $${QWT_LIB} $${QWT_INSTALL_LIBS}/$${QWT_LIB} $(DESTDIR)$(TARGET)
++    }
+ }
+ else {
+     TEMPLATE        = subdirs # do nothing

--- a/Source/Core/FFmpeg_Glue.cpp
+++ b/Source/Core/FFmpeg_Glue.cpp
@@ -34,6 +34,8 @@ extern "C"
 
 #ifndef WITH_SYSTEM_FFMPEG
 #include <config.h>
+#else
+#include <ctime>
 #endif
 }
 
@@ -2110,7 +2112,9 @@ string FFmpeg_Glue::FFmpeg_Version()
 int FFmpeg_Glue::FFmpeg_Year()
 {
 #ifdef WITH_SYSTEM_FFMPEG
-    return 0;
+    time_t t = std::time(0);
+    struct tm * now = std::localtime(&t);
+    return now->tm_year + 1900;
 #else
     return CONFIG_THIS_YEAR;
 #endif
@@ -2120,7 +2124,7 @@ int FFmpeg_Glue::FFmpeg_Year()
 string FFmpeg_Glue::FFmpeg_Compiler()
 {
 #ifdef WITH_SYSTEM_FFMPEG
-    return 0;
+    return "not available";
 #else
     return CC_IDENT;
 #endif
@@ -2130,7 +2134,7 @@ string FFmpeg_Glue::FFmpeg_Compiler()
 string FFmpeg_Glue::FFmpeg_Configuration()
 {
 #ifdef WITH_SYSTEM_FFMPEG
-    return 0;
+    return "not available";
 #else
     return FFMPEG_CONFIGURATION;
 #endif


### PR DESCRIPTION
For Mac users this enables building against homebrew installed versions of ffmpeg, freetype2, qt5 and qwt. The generated .app is not yet working due to the standard homebrew installation of qwt linking it to qt4, but I'll send a patch to them. Also I did some local modifications for not requiring blackmagic sdk and mocked some ffmpeg_glue calls due to not being completely compatible with homebrew version of ffmpeg. This should be easy to fix and I'll send a patch later.