### PR TITLE
Fix a crash while loading mp3

### DIFF
--- a/Source/Core/FFmpeg_Glue.cpp
+++ b/Source/Core/FFmpeg_Glue.cpp
@@ -1390,13 +1390,18 @@ void FFmpeg_Glue::Disable(const size_t Pos)
 //---------------------------------------------------------------------------
 double FFmpeg_Glue::TimeStampOfCurrentFrame(const size_t OutputPos)
 {
-    if (OutputPos>=OutputDatas.size())
-        return DBL_MAX;
-    outputdata* OutputData=OutputDatas[OutputPos];
-    if (!OutputData)
+    if (OutputPos >= OutputDatas.size())
         return DBL_MAX;
 
-    return ((double)OutputData->DecodedFrame->pkt_pts)*OutputData->Stream->time_base.num/OutputData->Stream->time_base.den;
+    outputdata *OutputData = OutputDatas[OutputPos];
+    if (!OutputData || !OutputData->DecodedFrame)
+        return DBL_MAX;
+
+    double pkt_pts = OutputData->DecodedFrame->pkt_pts;
+    int num = OutputData->Stream->time_base.num;
+    int den = OutputData->Stream->time_base.den;
+
+    return pkt_pts * num / den;
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
This fixes a crash loading the mp3 from this podcast episode:

https://talkpython.fm/episodes/show/37/python-cybersecurity-and-penetration-testing

Direct link: https://talkpython.fm/episodes/download/37/python-cybersecurity-and-penetration-testing.mp3

The crash is consistent (happens every time). Also interesting is that closing the file while the graph is being drawn causes a CPU spike to 100% for 20 to 30s but doesn't crash.