### PR TITLE
Thumbnails adjust to size

### DIFF
--- a/Source/GUI/TinyDisplay.h
+++ b/Source/GUI/TinyDisplay.h
@@ -9,6 +9,7 @@
 
 #include <QWidget>
 #include <QVector>
+#include <QResizeEvent>
 
 class FileInformation;
 class Control;
@@ -42,23 +43,25 @@ private:
     QPixmap                     emptyPixmap;
     QPixmap                     scaledLogo;
 
-    void                        updateThumbnails();
-
     int                         lastWidth;
 
     QHBoxLayout*                Layout;
 
 protected:
-    // File information
     FileInformation*            FileInfoData;
 
     bool                        needsUpdate;
     unsigned long               lastFramePos;
 
-    // Widgets
     QVector<QToolButton*>       thumbnails;
 
+    virtual void                resizeEvent(QResizeEvent *);
+
+Q_SIGNALS:
+    void                        resized();
+
 private Q_SLOTS:
+    void                        thumbsLayoutResized();
     void                        on_thumbnails_clicked(bool checked);
 };
 

--- a/Source/GUI/TinyDisplay.h
+++ b/Source/GUI/TinyDisplay.h
@@ -8,6 +8,7 @@
 #define GUI_TinyDisplay_H
 
 #include <QWidget>
+#include <QVector>
 
 class FileInformation;
 class Control;
@@ -15,6 +16,7 @@ class BigDisplay;
 
 class QLabel;
 class QToolButton;
+class QHBoxLayout;
 
 class TinyDisplay : public QWidget
 {
@@ -34,9 +36,17 @@ public:
 
 private:
     static const int            TOTAL_THUMBS = 9;
-    static const int            MID_THUMB_INDEX = 4;
+    static const int            THUMB_WIDTH = 84;
+    static const int            THUMB_HEIGHT = 84;
 
     QPixmap                     emptyPixmap;
+    QPixmap                     scaledLogo;
+
+    void                        updateThumbnails();
+
+    int                         lastWidth;
+
+    QHBoxLayout*                Layout;
 
 protected:
     // File information
@@ -46,7 +56,7 @@ protected:
     unsigned long               lastFramePos;
 
     // Widgets
-    QToolButton                *thumbnails[TOTAL_THUMBS];
+    QVector<QToolButton*>       thumbnails;
 
 private Q_SLOTS:
     void                        on_thumbnails_clicked(bool checked);


### PR DESCRIPTION
This enables the number of thumbs to be dynamically updated based on the screen size.

No maximum quantity was added (very easy todo, btw), so a lot of thumbs can be expected on wide monitors! 

Spacing between thumbs can be changed by changing THUMB_WANTED_WIDTH (default 120). This could be parameterized. Not sure if that is needed.

Works well for me but must be more tested.