### PR TITLE
Fix buffer resize issue

### DIFF
--- a/Source/Core/AudioStats.cpp
+++ b/Source/Core/AudioStats.cpp
@@ -71,7 +71,7 @@ void AudioStats::StatsFromExternalData (const string &Data)
                     const char* media_type=Frame->Attribute("media_type");
                     if (media_type && !strcmp(media_type, "audio"))
                     {
-                        if (x_Current>=Data_Reserved)
+                        if (x_Current >= Data_Reserved)
                             Data_Reserve(x_Current);
 
                         const char* Attribute;
@@ -251,12 +251,8 @@ void AudioStats::TimeStampFromFrame (struct AVFrame* Frame, size_t FramePos)
     if (Frequency==0)
         return; // Not supported
 
-    if (FramePos>=x_Current_Max)
-    {
-        x_Current_Max=FramePos+1;
-        if (x_Current_Max>Data_Reserved)
-            Data_Reserve(x_Current_Max);
-    }
+    if (FramePos >= Data_Reserved)
+        Data_Reserve(FramePos + 1);
 
     x[0][FramePos]=FramePos;
 
@@ -282,8 +278,8 @@ void AudioStats::TimeStampFromFrame (struct AVFrame* Frame, size_t FramePos)
         x[2][FramePos]=x[1][FramePos]/60;
         x[3][FramePos]=x[2][FramePos]/60;
     }
-    if (Frame->pkt_duration!=AV_NOPTS_VALUE)
-        durations[FramePos]=((double)Frame->pkt_duration)/Frequency;
+    if (Frame->pkt_duration != AV_NOPTS_VALUE)
+        durations[FramePos] = (double) Frame->pkt_duration / Frequency;
 }
 
 //---------------------------------------------------------------------------

--- a/Source/Core/CommonStats.cpp
+++ b/Source/Core/CommonStats.cpp
@@ -258,38 +258,47 @@ void CommonStats::Data_Reserve(size_t NewValue)
 {
     // Saving old data
     size_t                      Data_Reserved_Old = Data_Reserved;
-    double**                    x_Old = new double*[4];
-    memcpy (x_Old, x, sizeof(double*)*4);
-    double**                    y_Old = new double*[CountOfItems];
-    memcpy (y_Old, y, sizeof(double*)*CountOfItems);
-    double*                     durations_Old=durations;
-    bool*                       key_frames_Old=key_frames;
+    double**                    x_Old = x;
+    double**                    y_Old = y;
+    double*                     durations_Old = durations;
+    bool*                       key_frames_Old = key_frames;
 
     // Computing new value
-    while (Data_Reserved<NewValue+(1<<18)) //We reserve extra space, minimum 2^18 frames added
-        Data_Reserved<<=1;
+    while (Data_Reserved < NewValue + (1 << 18)) //We reserve extra space, minimum 2^18 frames added
+        Data_Reserved <<= 1;
+
+    size_t diff = Data_Reserved - Data_Reserved_Old;
 
     // Creating new data - x and y
     x = new double*[4];
-    for (size_t j=0; j<4; ++j)
+    for (size_t j = 0; j < 4; ++j)
     {
-        x[j]=new double[Data_Reserved];
-        memset(x[j], 0x00, Data_Reserved*sizeof(double));
-        memcpy(x[j], x_Old[j], Data_Reserved_Old*sizeof(double));
+        x[j] = new double[Data_Reserved];
+        memcpy(x[j], x_Old[j], Data_Reserved_Old * sizeof(double));
+        memset(&x[j][Data_Reserved_Old], 0x00, diff * sizeof(double));
+        delete[] x_Old[j];
     }
+
     y = new double*[CountOfItems];
-    for (size_t j=0; j<CountOfItems; ++j)
+    for (size_t j = 0; j < CountOfItems; ++j)
     {
         y[j] = new double[Data_Reserved];
-        memset(y[j], 0x00, Data_Reserved*sizeof(double));
-        memcpy(y[j], y_Old[j], Data_Reserved_Old*sizeof(double));
+        memcpy(y[j], y_Old[j], Data_Reserved_Old * sizeof(double));
+        memset(&y[j][Data_Reserved_Old], 0x00, diff * sizeof(double));
+        delete[] y_Old[j];
     }
 
     // Creating new data - Extra
     durations = new double[Data_Reserved];
-    memset(durations, 0x00, Data_Reserved*sizeof(double));
-    memcpy(durations, durations_Old, Data_Reserved_Old*sizeof(double));
+    memcpy(durations, durations_Old, Data_Reserved_Old * sizeof(double));
+    memset(&durations[Data_Reserved_Old], 0x00, diff * sizeof(double));
+
     key_frames = new bool[Data_Reserved];
-    memset(key_frames, 0x00, Data_Reserved*sizeof(bool));
-    memcpy(key_frames, key_frames_Old, Data_Reserved_Old*sizeof(bool));
+    memcpy(key_frames, key_frames_Old, Data_Reserved_Old * sizeof(bool));
+    memset(&key_frames[Data_Reserved_Old], 0x00, diff * sizeof(bool));
+
+    delete[] x_Old;
+    delete[] y_Old;
+    delete[] durations_Old;
+    delete[] key_frames_Old;
 }

--- a/Source/Core/CommonStats.h
+++ b/Source/Core/CommonStats.h
@@ -45,7 +45,7 @@ public:
     string                      Count_Get(size_t Pos);
     string                      Count2_Get(size_t Pos);
     string                      Percent_Get(size_t Pos);
-    
+
     // External data
     virtual void                StatsFromExternalData(const string &Data) = 0;
     virtual void                StatsFromFrame(struct AVFrame* Frame, int Width, int Height) = 0;


### PR DESCRIPTION
This fixes a crash when loading big files due to stats not correctly resizing its buffers, frees old memory and minimizes size of buffer initialization.