### PR TITLE
Re-enable filters action

### DIFF
--- a/Source/GUI/TinyDisplay.cpp
+++ b/Source/GUI/TinyDisplay.cpp
@@ -216,7 +216,10 @@ void TinyDisplay::on_thumbnails_clicked(bool)
             }
         }
     }
+}
 
+void TinyDisplay::LoadBigDisplay()
+{
     if (BigDisplayArea == NULL) {
         BigDisplayArea = new BigDisplay(this, FileInfoData);
 

--- a/Source/GUI/TinyDisplay.h
+++ b/Source/GUI/TinyDisplay.h
@@ -34,6 +34,7 @@ public:
     // Commands
     void                        Update();
     void                        Filters_Show(); //Quick hack for showing filters
+    void                        LoadBigDisplay();
 
 private:
     static const int            TOTAL_THUMBS = 9;

--- a/Source/GUI/mainwindow.cpp
+++ b/Source/GUI/mainwindow.cpp
@@ -341,6 +341,8 @@ void MainWindow::on_actionPreferences_triggered()
 //---------------------------------------------------------------------------
 void MainWindow::on_actionFiltersLayout_triggered()
 {
+    if (TinyDisplayArea)
+        TinyDisplayArea->LoadBigDisplay();
 }
 
 //---------------------------------------------------------------------------

--- a/Source/GUI/mainwindow.ui
+++ b/Source/GUI/mainwindow.ui
@@ -72,6 +72,7 @@
     </property>
     <addaction name="actionFilesList"/>
     <addaction name="actionGraphsLayout"/>
+    <addaction name="separator"/>
     <addaction name="actionFiltersLayout"/>
     <addaction name="separator"/>
     <addaction name="actionWindowOut"/>
@@ -167,10 +168,11 @@
    <addaction name="separator"/>
    <addaction name="actionZoomIn"/>
    <addaction name="actionZoomOut"/>
+   <addaction name="separator"/>
+   <addaction name="actionFiltersLayout"/>
    <addaction name="actionWindowOut"/>
    <addaction name="actionFilesList"/>
    <addaction name="actionGraphsLayout"/>
-   <addaction name="actionFiltersLayout"/>
    <addaction name="separator"/>
    <addaction name="actionGettingStarted"/>
   </widget>
@@ -305,9 +307,6 @@
    </property>
   </action>
   <action name="actionFiltersLayout">
-   <property name="checkable">
-    <bool>true</bool>
-   </property>
    <property name="text">
     <string>Filters layout</string>
    </property>

--- a/Source/GUI/mainwindow_Ui.cpp
+++ b/Source/GUI/mainwindow_Ui.cpp
@@ -141,7 +141,6 @@ void MainWindow::Ui_Init()
     Prefs=new Preferences(this);
 
     //Temp
-    ui->actionFiltersLayout->setVisible(false);
     ui->actionWindowOut->setVisible(false);
     ui->actionPrint->setVisible(false);
 


### PR DESCRIPTION
This re-enables the filters action (opens filters display on current frame).

I removed the `checkable` feature (doesn't make sense) and moved it to a position closer to other semantically similar buttons leaving the `checkable` (Graphs layout / Files list) actions grouped together.