### PR TITLE
docs/dataformat.html - adds idet/ssim to cli qctools.xml.gz example

### DIFF
--- a/Source/Resource/Help/Data Format/Data Format.html
+++ b/Source/Resource/Help/Data Format/Data Format.html
@@ -123,9 +123,9 @@
             </li>
             <li>Via FFmpeg (version 2.3 or later)<br />
                 For a file with video and audio named EXAMPLE.mov<br />
-                ffprobe -f lavfi -i "movie=EXAMPLE.mov:s=v+a[in0][in1],[in0]signalstats=stat=tout+vrep+brng,cropdetect=reset=1:round=1,split[a][b];[a]field=top[a1];[b]field=bottom[b1],[a1][b1]psnr[out0];[in1]ebur128=metadata=1,astats=metadata=1:reset=1:length=0.4[out1]" -show_frames -show_versions -of xml=x=1:q=1 -noprivate | gzip &gt; EXAMPLE.mov.qctools.xml.gz<br />
+                ffprobe -f lavfi -i "movie=EXAMPLE.mov:s=v+a[in0][in1],[in0]signalstats=stat=tout+vrep+brng,cropdetect=reset=1:round=1,idet=half_life=1,split[a][b];[a]field=top[a1];[b]field=bottom,split[b1][b2];[a1][b1]psnr[c1];[c1][b2]ssim[out0];[in1]ebur128=metadata=1,astats=metadata=1:reset=1:length=0.4[out1]" -show_frames -show_versions -of xml=x=1:q=1 -noprivate | gzip &gt; EXAMPLE.mov.qctools.xml.gz<br />
                 For a file with video and no audio named EXAMPLE.mov<br />
-                ffprobe -f lavfi -i "movie=EXAMPLE.mov,signalstats=stat=tout+vrep+brng,cropdetect=reset=1:round=1,split[a][b];[a]field=top[a1];[b]field=bottom[b1],[a1][b1]psnr" -show_frames -show_versions -of xml=x=1:q=1 -noprivate | gzip &gt; EXAMPLE.mov.qctools.xml.gz
+                ffprobe -f lavfi -i "movie=EXAMPLE.mov,signalstats=stat=tout+vrep+brng,cropdetect=reset=1:round=1,idet=half_life=1,split[a][b];[a]field=top[a1];[b]field=bottom,split[b1][b2];[a1][b1]psnr[c1];[c1][b2]ssim" -show_frames -show_versions -of xml=x=1:q=1 -noprivate | gzip &gt; EXAMPLE.mov.qctools.xml.gz
             </li>
         </ol>
         <h3 style="color:blue">


### PR DESCRIPTION
Command lines pulled directly from the FileInformation.cpp source code.
One thing - Ffmpeg2.3 is no longer the minimum version required to run this command. I usually compile from HEAD, so I'm not sure which version contains all the latest filters required for this command, I'd imagine that even 3.0 is not recent enough?