### PR TITLE
Remove C++11 code

### DIFF
--- a/Project/QtCreator/QCTools.pro
+++ b/Project/QtCreator/QCTools.pro
@@ -4,7 +4,7 @@ greaterThan(QT_MAJOR_VERSION, 4): QT += widgets printsupport
 TARGET = QCTools
 TEMPLATE = app
 
-CONFIG += c++11 qt no_keywords
+CONFIG += qt no_keywords
 
 USE_BREW = $$(QCTOOLS_USE_BREW)
 

--- a/Source/Core/FFmpeg_Glue.cpp
+++ b/Source/Core/FFmpeg_Glue.cpp
@@ -528,7 +528,7 @@ void FFmpeg_Glue::outputdata::AddThumbnail()
 {
     if (Thumbnails.size()%Thumbnails_Modulo)
     {
-        Thumbnails.push_back(NULL);
+        Thumbnails.push_back(static_cast<FFmpeg_Glue::bytes*>(NULL));
         return; // Not wanting to saturate memory. TODO: Find a smarter way to detect memory usage
     }
         
@@ -770,7 +770,7 @@ FFmpeg_Glue::FFmpeg_Glue (const string &FileName_, activealltracks ActiveAllTrac
     WithStats(WithStats_),
     FileName(FileName_),
     InputDatas_Copy(false),
-    mutex(nullptr),
+    mutex(NULL),
     // Encode
     Encode_FormatContext(NULL)
 {
@@ -822,7 +822,7 @@ FFmpeg_Glue::FFmpeg_Glue (const string &FileName_, activealltracks ActiveAllTrac
                                                         InputDatas.push_back(InputData);
                                                     }
                                                     break;
-                        default: InputDatas.push_back(NULL);
+                        default: InputDatas.push_back(static_cast<FFmpeg_Glue::inputdata*>(NULL));
                     }
                 }
             }
@@ -917,7 +917,7 @@ QByteArray FFmpeg_Glue::Thumbnail_Get(size_t Pos, size_t FramePos)
     if (Pos>=OutputDatas.size() || !OutputDatas[Pos] || !OutputDatas[Pos]->Enabled)
         return NULL;
 
-    auto bytes = OutputDatas[Pos]->Thumbnails[FramePos];
+    bytes* bytes = OutputDatas[Pos]->Thumbnails[FramePos];
     return QByteArray(reinterpret_cast<char*> (bytes->Data), bytes->Size);
 }
 
@@ -1039,7 +1039,7 @@ void FFmpeg_Glue::AddOutput(size_t FilterPos, int Scale_Width, int Scale_Height,
 
         if (InputData && InputData->Type==FilterType)
         {
-            OutputDatas.push_back(NULL);
+            OutputDatas.push_back(static_cast<FFmpeg_Glue::outputdata*>(NULL));
             ModifyOutput(InputPos, OutputDatas.size()-1, FilterPos, Scale_Width, Scale_Height, OutputMethod, FilterType, Filter);
         }
     }
@@ -1518,7 +1518,7 @@ void FFmpeg_Glue::setThreadSafe(bool enable)
         if(mutex)
         {
             delete mutex;
-            mutex = nullptr;
+            mutex = NULL;
         }
     }
 }
@@ -1827,7 +1827,7 @@ double FFmpeg_Glue::OutputDAR_Get(int Pos)
 
     if (OutputData)
     {
-        auto DecodedFrame = OutputData->DecodedFrame;
+        AVFrame* DecodedFrame = OutputData->DecodedFrame;
 
         if (!DecodedFrame)
             DAR=4.0/3.0; // TODO: video frame DAR

--- a/Source/GUI/BigDisplay.cpp
+++ b/Source/GUI/BigDisplay.cpp
@@ -2072,7 +2072,7 @@ void BigDisplay::ShowPicture ()
     ShouldUpate=false;
 
     Picture->FrameAtPosition(Frames_Pos);
-    auto image = Picture->Image_Get(0);
+    QImage image = Picture->Image_Get(0);
     if (!image.isNull())
     {
         Image_Width = image.width();
@@ -2321,10 +2321,10 @@ void BigDisplay::updateSelection(int Pos, ImageLabel* image, options& opts)
             strcmp(Filters[Pos].Name, "Vectorscope Target") ==  0 ||
             strcmp(Filters[Pos].Name, "Zoom") ==  0)
     {
-        auto& xSpinBox = opts.Sliders_SpinBox[0];
-        auto& ySpinBox = opts.Sliders_SpinBox[1];
-        auto& wSpinBox = opts.Sliders_SpinBox[2];
-        auto& hSpinBox = opts.Sliders_SpinBox[3];
+        DoubleSpinBoxWithSlider* xSpinBox = opts.Sliders_SpinBox[0];
+        DoubleSpinBoxWithSlider* ySpinBox = opts.Sliders_SpinBox[1];
+        DoubleSpinBoxWithSlider* wSpinBox = opts.Sliders_SpinBox[2];
+        DoubleSpinBoxWithSlider* hSpinBox = opts.Sliders_SpinBox[3];
 
         image->setSelectionArea(xSpinBox->value(), ySpinBox->value(), wSpinBox->value(), hSpinBox->value());
 
@@ -2336,29 +2336,15 @@ void BigDisplay::updateSelection(int Pos, ImageLabel* image, options& opts)
         connect(wSpinBox, &DoubleSpinBoxWithSlider::controlValueChanged, image, &ImageLabel::changeSelectionWidth);
         connect(hSpinBox, &DoubleSpinBoxWithSlider::controlValueChanged, image, &ImageLabel::changeSelectionHeight);
 
-        connect(image, &ImageLabel::selectionChangeFinished, [&](const QRectF& geometry) {
-            qDebug() << "x: " << geometry.x();
-            qDebug() << "y: " << geometry.y();
+        connect(image, SIGNAL(selectionChangeFinished(const QRectF&)), xSpinBox, SLOT(selectionChangeFinishedX(const QRectF&)));
+        connect(image, SIGNAL(selectionChangeFinished(const QRectF&)), ySpinBox, SLOT(selectionChangeFinishedY(const QRectF&)));
+        connect(image, SIGNAL(selectionChangeFinished(const QRectF&)), wSpinBox, SLOT(selectionChangeFinishedWidth(const QRectF&)));
+        connect(image, SIGNAL(selectionChangeFinished(const QRectF&)), hSpinBox, SLOT(selectionChangeFinishedHeight(const QRectF&)));
 
-            xSpinBox->applyValue(geometry.topLeft().x(), true);
-            ySpinBox->applyValue(geometry.topLeft().y(), true);
-            wSpinBox->applyValue(geometry.width(), true);
-            hSpinBox->applyValue(geometry.height(), true);
-
-        });
-
-        connect(image, &ImageLabel::selectionChanged, [&](const QRectF& geometry) {
-            qDebug() << "x: " << geometry.x();
-            qDebug() << "y: " << geometry.y();
-
-            qDebug() << "width: " << geometry.width();
-            qDebug() << "height: " << geometry.height();
-
-            xSpinBox->applyValue(geometry.x(), false);
-            ySpinBox->applyValue(geometry.y(), false);
-            wSpinBox->applyValue(geometry.width(), false);
-            hSpinBox->applyValue(geometry.height(), false);
-        });
+        connect(image, SIGNAL(selectionChanged(const QRectF&)), xSpinBox, SLOT(selectionChangedX(const QRectF&)));
+        connect(image, SIGNAL(selectionChanged(const QRectF&)), ySpinBox, SLOT(selectionChangedY(const QRectF&)));
+        connect(image, SIGNAL(selectionChanged(const QRectF&)), wSpinBox, SLOT(selectionChangedWidth(const QRectF&)));
+        connect(image, SIGNAL(selectionChanged(const QRectF&)), hSpinBox, SLOT(selectionChangedHeight(const QRectF&)));
     }
     else
     {
@@ -2482,4 +2468,51 @@ void BigDisplay::on_Full_triggered()
         setWindowState(Qt::WindowActive);
     else
         setWindowState(Qt::WindowMaximized);
+}
+
+//---------------------------------------------------------------------------
+void DoubleSpinBoxWithSlider::selectionChangedX(const QRectF& geometry)
+{
+    applyValue(geometry.x(), false);
+}
+
+//---------------------------------------------------------------------------
+void DoubleSpinBoxWithSlider::selectionChangedY(const QRectF& geometry)
+{
+    applyValue(geometry.y(), false);
+}
+
+//---------------------------------------------------------------------------
+void DoubleSpinBoxWithSlider::selectionChangedWidth(const QRectF& geometry)
+{
+    applyValue(geometry.width(), false);
+}
+
+//---------------------------------------------------------------------------
+void DoubleSpinBoxWithSlider::selectionChangedHeight(const QRectF& geometry){
+    applyValue(geometry.height(), false);
+}
+
+//---------------------------------------------------------------------------
+void DoubleSpinBoxWithSlider::selectionChangeFinishedX(const QRectF& geometry)
+{
+    applyValue(geometry.topLeft().x(), true);
+}
+
+//---------------------------------------------------------------------------
+void DoubleSpinBoxWithSlider::selectionChangeFinishedY(const QRectF& geometry)
+{
+    applyValue(geometry.topLeft().y(), true);
+}
+
+//---------------------------------------------------------------------------
+void DoubleSpinBoxWithSlider::selectionChangeFinishedWidth(const QRectF& geometry)
+{
+    applyValue(geometry.width(), true);
+}
+
+//---------------------------------------------------------------------------
+void DoubleSpinBoxWithSlider::selectionChangeFinishedHeight(const QRectF& geometry)
+{
+    applyValue(geometry.height(), true);
 }

--- a/Source/GUI/BigDisplay.h
+++ b/Source/GUI/BigDisplay.h
@@ -83,6 +83,14 @@ private:
 public Q_SLOTS:
     void on_valueChanged(double);
     void on_sliderMoved(int);
+    void selectionChangedX(const QRectF& geometry);
+    void selectionChangedY(const QRectF& geometry);
+    void selectionChangedWidth(const QRectF& geometry);
+    void selectionChangedHeight(const QRectF& geometry);
+    void selectionChangeFinishedX(const QRectF& geometry);
+    void selectionChangeFinishedY(const QRectF& geometry);
+    void selectionChangeFinishedWidth(const QRectF& geometry);
+    void selectionChangeFinishedHeight(const QRectF& geometry);
 
 Q_SIGNALS:
     void controlValueChanged(double);

--- a/Source/GUI/Control.cpp
+++ b/Source/GUI/Control.cpp
@@ -231,8 +231,8 @@ void Control::stop()
         qDebug() << "Thread->wait()";
         Thread->wait();
         qDebug() << "after Thread->wait()";
-        Thread = nullptr;
-        Timer = nullptr;
+        Thread = NULL;
+        Timer = NULL;
     }
 }
 
@@ -816,7 +816,7 @@ void Control::TimeOut_Init()
     startFrameTimeStamp = QTime::currentTime();
     lastRenderedFrame = -1;
 
-    auto averageFrameRate = FileInfoData->averageFrameRate();
+    qreal averageFrameRate = FileInfoData->averageFrameRate();
     averageFrameDuration = averageFrameRate != 0.0 ? 1000.0 / averageFrameRate : 0.0;
 
     if (!Timer)
@@ -893,10 +893,10 @@ void Control::TimeOut ()
 				setCurrentFrame(++lastRenderedFrame);
         } else {
 
-            auto currentTime = QTime::currentTime();
-            auto timeFromStartFrame = startFrameTimeStamp.msecsTo(currentTime);
+            QTime currentTime = QTime::currentTime();
+            int timeFromStartFrame = startFrameTimeStamp.msecsTo(currentTime);
 
-            auto framesFromStartFrame = floor(qreal(timeFromStartFrame) / averageFrameDuration);
+            double framesFromStartFrame = floor(qreal(timeFromStartFrame) / averageFrameDuration);
             if(SelectedSpeed == Speed_M0 || SelectedSpeed == Speed_P0) {
                 framesFromStartFrame /= 2;
             } else if(SelectedSpeed == Speed_M2 || SelectedSpeed == Speed_P2) {

--- a/Source/GUI/FileInformation.cpp
+++ b/Source/GUI/FileInformation.cpp
@@ -40,7 +40,7 @@ void FileInformation::run()
     if (blackmagicDeckLink_Glue)
     {
         blackmagicDeckLink_Glue->Glue=Glue;
-            
+
         for (;;)
         {
             switch (blackmagicDeckLink_Glue->Config_Out.Status)
@@ -48,12 +48,12 @@ void FileInformation::run()
                 case BlackmagicDeckLink_Glue::instancied:
                                                         blackmagicDeckLink_Glue->Start();
                                                         break;
-                case BlackmagicDeckLink_Glue::finished: 
+                case BlackmagicDeckLink_Glue::finished:
                                                         WantToStop=true;
                                                         break;
                 default : ;
             }
-                
+
             if (WantToStop)
                 break;
             yieldCurrentThread();
@@ -463,7 +463,7 @@ QPixmap FileInformation::Picture_Get (size_t Pos)
     }
     else
     {
-        auto Thumbnail = Glue->Thumbnail_Get(0, Pos);
+        QByteArray Thumbnail = Glue->Thumbnail_Get(0, Pos);
         if (!Thumbnail.isEmpty())
             Pixmap.loadFromData(Thumbnail);
         else
@@ -480,7 +480,7 @@ int FileInformation::Frames_Count_Get (size_t Stats_Pos)
 {
     if (Stats_Pos==(size_t)-1)
         Stats_Pos=ReferenceStream_Pos_Get();
-    
+
     if (Stats_Pos>=Stats.size())
         return -1;
     return Stats[Stats_Pos]->x_Max[0];
@@ -514,7 +514,7 @@ int FileInformation::Frames_Pos_Get (size_t Stats_Pos)
     }
     else
         Pos=Frames_Pos;
-    
+
     return Pos;
 }
 
@@ -579,7 +579,7 @@ void FileInformation::Frames_Pos_Set (int Pos, size_t Stats_Pos)
                 break;
             }
     }
-    
+
     if (Pos<0)
         Pos=0;
     if (Pos>=ReferenceStat()->x_Current_Max)
@@ -628,7 +628,7 @@ qreal FileInformation::averageFrameRate() const
     if(!Glue)
         return 0;
 
-    auto splitted = QString::fromStdString(Glue->AvgVideoFrameRate_Get()).split("/");
+    QStringList splitted = QString::fromStdString(Glue->AvgVideoFrameRate_Get()).split("/");
     if(splitted.length() == 1)
         return splitted[0].toDouble();
 

--- a/Source/GUI/FilesList.cpp
+++ b/Source/GUI/FilesList.cpp
@@ -134,10 +134,10 @@ public:
 		// check if both are integers
 		{
 			bool ok = false;
-			auto intValue = text().toInt(&ok);
+			int intValue = text().toInt(&ok);
 			if (ok)
 			{
-				auto otherIntValue = other.text().toInt(&ok);
+				int otherIntValue = other.text().toInt(&ok);
 				if (ok) {
 					return intValue < otherIntValue;
 				}
@@ -147,10 +147,10 @@ public:
 		// check if both are doubles
 		{
 			bool ok = false;
-			auto doubleValue = text().toDouble(&ok);
+			double doubleValue = text().toDouble(&ok);
 			if (ok)
 			{
-				auto otherDoubleValue = other.text().toDouble(&ok);
+				double otherDoubleValue = other.text().toDouble(&ok);
 				if (ok) {
 					return doubleValue < otherDoubleValue;
 				}

--- a/Source/GUI/Plots.cpp
+++ b/Source/GUI/Plots.cpp
@@ -58,16 +58,16 @@ Plots::Plots( QWidget *parent, FileInformation* fileInformation ) :
     // plots and legends
     m_plots = new Plot**[m_fileInfoData->Stats.size()];
     m_plotsCount = 0;
-    
+
     for ( size_t streamPos = 0; streamPos < m_fileInfoData->Stats.size(); streamPos++ )
     {
         if (m_fileInfoData->Stats[streamPos])
         {
             size_t type = m_fileInfoData->Stats[streamPos]->Type_Get();
             size_t countOfGroups = PerStreamType[type].CountOfGroups;
-        
+
             m_plots[streamPos] = new Plot*[countOfGroups + 1]; //+1 for axix
-    
+
             for ( size_t group = 0; group < countOfGroups; group++ )
             {
                 if (m_fileInfoData->ActiveFilters[PerStreamType[type].PerGroup[group].ActiveFilterGroup])
@@ -192,7 +192,7 @@ FrameInterval Plots::visibleFrames() const
 //---------------------------------------------------------------------------
 void Plots::onCurrentFrameChanged()
 {
-    // position of the current frame has changed 
+    // position of the current frame has changed
 
     if ( isZoomed() )
     {
@@ -268,13 +268,13 @@ void Plots::updateSamples( Plot* plot )
     const size_t plotGroup = plot->group();
     const CommonStats* stat = stats( plot->streamPos() );
 
-    auto streamInfo = PerStreamType[plotType];
+    stream_info streamInfo = PerStreamType[plotType];
 
-    for(auto j = 0; j < streamInfo.PerGroup[plotGroup].Count; ++j)
+    for(size_t j = 0; j < streamInfo.PerGroup[plotGroup].Count; ++j)
     {
-        auto xData = stat->x[m_dataTypeIndex];
-        auto yIndex = streamInfo.PerGroup[plotGroup].Start + j;
-        auto yData = stat->y[yIndex];
+        double* xData = stat->x[m_dataTypeIndex];
+        unsigned yIndex = streamInfo.PerGroup[plotGroup].Start + j;
+        double* yData = stat->y[yIndex];
 
         plot->setCurveSamples( j, xData, yData, stat->x_Current );
     }
@@ -318,7 +318,7 @@ void Plots::alignYAxes()
         if ( m_fileInfoData->Stats[streamPos] && m_plots[streamPos] )
         {
             size_t type = m_fileInfoData->Stats[streamPos]->Type_Get();
-        
+
             for ( int group = 0; group < PerStreamType[type].CountOfGroups; group++ )
                 if (m_plots[streamPos][group] && m_plots[streamPos] )
             {
@@ -340,7 +340,7 @@ void Plots::alignYAxes()
         if ( m_fileInfoData->Stats[streamPos] && m_plots[streamPos] )
         {
             size_t type = m_fileInfoData->Stats[streamPos]->Type_Get();
-        
+
             for ( int group = 0; group < PerStreamType[type].CountOfGroups; group++ )
                 if (m_plots[streamPos][group])
             {
@@ -358,7 +358,7 @@ bool Plots::eventFilter( QObject *object, QEvent *event )
             if ( m_fileInfoData->Stats[streamPos] && m_plots[streamPos] )
             {
                 size_t type = m_fileInfoData->Stats[streamPos]->Type_Get();
-        
+
                 for ( int group = 0; group < PerStreamType[type].CountOfGroups; group++ )
                 {
                     if ( m_plots[streamPos][group] && m_plots[streamPos][group]->isVisibleTo( this ) )
@@ -391,7 +391,7 @@ void Plots::adjustGroupMax(int group, int bitsPerRawSample)
     }
 }
 
-void Plots::changeOrder(QList<std::tuple<int, int> > orderedFilterInfo)
+void Plots::changeOrder(QList<std::tr1::tuple<int, int> > orderedFilterInfo)
 {
     if(orderedFilterInfo.empty())
     {
@@ -401,37 +401,40 @@ void Plots::changeOrder(QList<std::tuple<int, int> > orderedFilterInfo)
 
     qDebug() << "changeOrder: items = " << orderedFilterInfo.count();
 
-    auto gridLayout = static_cast<QGridLayout*> (layout());
-    auto rowsCount = gridLayout->rowCount();
+    QGridLayout* gridLayout = static_cast<QGridLayout*> (layout());
+    int rowsCount = gridLayout->rowCount();
 
     Q_ASSERT(m_plotsCount <= rowsCount);
 
     qDebug() << "plotsCount: " << m_plotsCount;
 
-    QList <std::tuple<size_t, size_t, size_t>> currentOrderedPlotsInfo;
-    QList <std::tuple<size_t, size_t, size_t>> expectedOrderedPlotsInfo;
+    QList <std::tr1::tuple<size_t, size_t, size_t> > currentOrderedPlotsInfo;
+    QList <std::tr1::tuple<size_t, size_t, size_t> > expectedOrderedPlotsInfo;
 
-    for(auto row = 0; row < m_plotsCount; ++row)
+    for(int row = 0; row < m_plotsCount; ++row)
     {
-        auto plotItem = gridLayout->itemAtPosition(row, 0);
-        auto legendItem = gridLayout->itemAtPosition(row, 1);
+        QLayoutItem* plotItem = gridLayout->itemAtPosition(row, 0);
+        QLayoutItem* legendItem = gridLayout->itemAtPosition(row, 1);
 
         Q_ASSERT(plotItem);
         Q_ASSERT(legendItem);
 
-        auto plot = qobject_cast<Plot*> (plotItem->widget());
+        Plot* plot = qobject_cast<Plot*> (plotItem->widget());
         Q_ASSERT(plot);
 
-        currentOrderedPlotsInfo.push_back(std::make_tuple(plot->group(), plot->type(), plot->streamPos()));
+        currentOrderedPlotsInfo.push_back(std::tr1::make_tuple(plot->group(), plot->type(), plot->streamPos()));
     }
 
-    for(auto filterInfo : orderedFilterInfo)
+
+    QList<std::tr1::tuple<int, int> >::iterator filterInfo;
+    for(filterInfo = orderedFilterInfo.begin(); filterInfo != orderedFilterInfo.end(); ++filterInfo)
     {
-        for(auto plotInfo : currentOrderedPlotsInfo)
+        QList <std::tr1::tuple<size_t, size_t, size_t> >::iterator plotInfo;
+        for(plotInfo = currentOrderedPlotsInfo.begin(); plotInfo != currentOrderedPlotsInfo.end(); ++plotInfo)
         {
-            if(std::get<0>(plotInfo) == std::get<0>(filterInfo) && std::get<1>(plotInfo) == std::get<1>(filterInfo))
+            if(std::tr1::get<0>(*plotInfo) == std::tr1::get<0>(*filterInfo) && std::tr1::get<1>(*plotInfo) == std::tr1::get<1>(*filterInfo))
             {
-                expectedOrderedPlotsInfo.push_back(plotInfo);
+                expectedOrderedPlotsInfo.push_back(*plotInfo);
             }
         }
     }
@@ -440,45 +443,45 @@ void Plots::changeOrder(QList<std::tuple<int, int> > orderedFilterInfo)
     if(currentOrderedPlotsInfo.length() != expectedOrderedPlotsInfo.length())
         return;
 
-    for(auto i = 0; i < expectedOrderedPlotsInfo.length(); ++i)
+    for(int i = 0; i < expectedOrderedPlotsInfo.length(); ++i)
     {
-        qDebug() << "cg: " << std::get<0>(currentOrderedPlotsInfo[i])
+        qDebug() << "cg: " << std::tr1::get<0>(currentOrderedPlotsInfo[i])
                  << ", "
-                 << "ct: " << std::get<1>(currentOrderedPlotsInfo[i])
+                 << "ct: " << std::tr1::get<1>(currentOrderedPlotsInfo[i])
                  << ", "
-                 << "cp: " << std::get<2>(currentOrderedPlotsInfo[i])
+                 << "cp: " << std::tr1::get<2>(currentOrderedPlotsInfo[i])
                  << ", "
-                 << "eg: " << std::get<0>(expectedOrderedPlotsInfo[i])
+                 << "eg: " << std::tr1::get<0>(expectedOrderedPlotsInfo[i])
                  << ", "
-                 << "et: " << std::get<1>(expectedOrderedPlotsInfo[i])
+                 << "et: " << std::tr1::get<1>(expectedOrderedPlotsInfo[i])
                  << ", "
-                 << "ep: " << std::get<2>(expectedOrderedPlotsInfo[i]);
+                 << "ep: " << std::tr1::get<2>(expectedOrderedPlotsInfo[i]);
     }
 
-    for(auto i = 0; i < expectedOrderedPlotsInfo.length(); ++i)
+    for(int i = 0; i < expectedOrderedPlotsInfo.length(); ++i)
     {
         if(expectedOrderedPlotsInfo[i] != currentOrderedPlotsInfo[i])
         {
             // search current item which we should put at expected position
-            for(auto j = 0; j < expectedOrderedPlotsInfo.length(); ++j)
+            for(int j = 0; j < expectedOrderedPlotsInfo.length(); ++j)
             {
                 if(expectedOrderedPlotsInfo[i] == currentOrderedPlotsInfo[j])
                 {
                     qDebug() << "i: " << i << ", j: " << j;
 
-                    auto plotWidget = gridLayout->itemAtPosition(j, 0)->widget();
-                    auto legendWidget = gridLayout->itemAtPosition(j, 1)->widget();
+                    QWidget* plotWidget = gridLayout->itemAtPosition(j, 0)->widget();
+                    QWidget* legendWidget = gridLayout->itemAtPosition(j, 1)->widget();
 
                     {
-                        auto plot = qobject_cast<Plot*> (plotWidget);
+                        Plot* plot = qobject_cast<Plot*> (plotWidget);
                         qDebug() << "jg: " << plot->group() << ", t: " << plot->type() << ", p: " << plot->streamPos() << ", ptr = " << plot;
                     }
 
-                    auto swapPlotWidget = gridLayout->itemAtPosition(i, 0)->widget();
-                    auto swapLegendWidget = gridLayout->itemAtPosition(i, 1)->widget();
+                    QWidget* swapPlotWidget = gridLayout->itemAtPosition(i, 0)->widget();
+                    QWidget* swapLegendWidget = gridLayout->itemAtPosition(i, 1)->widget();
 
                     {
-                        auto plot = qobject_cast<Plot*> (swapPlotWidget);
+                        Plot* plot = qobject_cast<Plot*> (swapPlotWidget);
                         qDebug() << "ig: " << plot->group() << ", t: " << plot->type() << ", p: " << plot->streamPos() << ", ptr = " << plot;
                     }
 
@@ -505,19 +508,19 @@ void Plots::changeOrder(QList<std::tuple<int, int> > orderedFilterInfo)
 
     Q_ASSERT(rowsCount == gridLayout->rowCount());
 
-    for(auto row = 0; row < m_plotsCount; ++row)
+    for(int row = 0; row < m_plotsCount; ++row)
     {
-        auto plotItem = gridLayout->itemAtPosition(row, 0);
-        auto legendItem = gridLayout->itemAtPosition(row, 1);
+        QLayoutItem* plotItem = gridLayout->itemAtPosition(row, 0);
+        QLayoutItem* legendItem = gridLayout->itemAtPosition(row, 1);
 
         Q_ASSERT(plotItem);
         Q_ASSERT(legendItem);
 
-        auto plot = qobject_cast<Plot*> (plotItem->widget());
+        Plot* plot = qobject_cast<Plot*> (plotItem->widget());
         Q_ASSERT(plot);
 
-        Q_ASSERT(plot->group() == std::get<0>(expectedOrderedPlotsInfo[row]) &&
-                 plot->type() == std::get<1>(expectedOrderedPlotsInfo[row]));
+        Q_ASSERT(plot->group() == std::tr1::get<0>(expectedOrderedPlotsInfo[row]) &&
+                 plot->type() == std::tr1::get<1>(expectedOrderedPlotsInfo[row]));
     }
 }
 
@@ -525,7 +528,7 @@ void Plots::alignXAxis( const Plot* plot )
 {
     const QWidget* canvas = plot->canvas();
 
-    QRect r = canvas->geometry(); 
+    QRect r = canvas->geometry();
     r.moveTopLeft( mapFromGlobal( plot->mapToGlobal( r.topLeft() ) ) );
 
     int left = r.left();
@@ -608,7 +611,7 @@ void Plots::zoomXAxis( ZoomTypes zoomType )
         m_zoomFactor--;
     else if ( zoomType == ZoomOneToOne)
         m_zoomFactor = 0;
-        
+
     qDebug() << "m_zoomFactor: " << m_zoomFactor;
     int numVisibleFrames = m_fileInfoData->Frames_Count_Get() >> m_zoomFactor;
 

--- a/Source/GUI/Plots.cpp
+++ b/Source/GUI/Plots.cpp
@@ -391,7 +391,7 @@ void Plots::adjustGroupMax(int group, int bitsPerRawSample)
     }
 }
 
-void Plots::changeOrder(QList<std::tr1::tuple<int, int> > orderedFilterInfo)
+void Plots::changeOrder(QList<QPair<int, int> > orderedFilterInfo)
 {
     if(orderedFilterInfo.empty())
     {
@@ -408,8 +408,8 @@ void Plots::changeOrder(QList<std::tr1::tuple<int, int> > orderedFilterInfo)
 
     qDebug() << "plotsCount: " << m_plotsCount;
 
-    QList <std::tr1::tuple<size_t, size_t, size_t> > currentOrderedPlotsInfo;
-    QList <std::tr1::tuple<size_t, size_t, size_t> > expectedOrderedPlotsInfo;
+    QList<QList<size_t> > currentOrderedPlotsInfo;
+    QList<QList<size_t> > expectedOrderedPlotsInfo;
 
     for(int row = 0; row < m_plotsCount; ++row)
     {
@@ -422,17 +422,17 @@ void Plots::changeOrder(QList<std::tr1::tuple<int, int> > orderedFilterInfo)
         Plot* plot = qobject_cast<Plot*> (plotItem->widget());
         Q_ASSERT(plot);
 
-        currentOrderedPlotsInfo.push_back(std::tr1::make_tuple(plot->group(), plot->type(), plot->streamPos()));
+        currentOrderedPlotsInfo.push_back(QList<size_t>() << plot->group() << plot->type() << plot->streamPos());
     }
 
 
-    QList<std::tr1::tuple<int, int> >::iterator filterInfo;
+    QList<QPair<int, int> >::iterator filterInfo;
     for(filterInfo = orderedFilterInfo.begin(); filterInfo != orderedFilterInfo.end(); ++filterInfo)
     {
-        QList <std::tr1::tuple<size_t, size_t, size_t> >::iterator plotInfo;
+        QList<QList<size_t> >::iterator plotInfo;
         for(plotInfo = currentOrderedPlotsInfo.begin(); plotInfo != currentOrderedPlotsInfo.end(); ++plotInfo)
         {
-            if(std::tr1::get<0>(*plotInfo) == std::tr1::get<0>(*filterInfo) && std::tr1::get<1>(*plotInfo) == std::tr1::get<1>(*filterInfo))
+            if(plotInfo->at(0) == filterInfo->first && plotInfo->at(1) == filterInfo->second)
             {
                 expectedOrderedPlotsInfo.push_back(*plotInfo);
             }
@@ -445,17 +445,17 @@ void Plots::changeOrder(QList<std::tr1::tuple<int, int> > orderedFilterInfo)
 
     for(int i = 0; i < expectedOrderedPlotsInfo.length(); ++i)
     {
-        qDebug() << "cg: " << std::tr1::get<0>(currentOrderedPlotsInfo[i])
+        qDebug() << "cg: " << currentOrderedPlotsInfo[i].at(0)
                  << ", "
-                 << "ct: " << std::tr1::get<1>(currentOrderedPlotsInfo[i])
+                 << "ct: " << currentOrderedPlotsInfo[i].at(1)
                  << ", "
-                 << "cp: " << std::tr1::get<2>(currentOrderedPlotsInfo[i])
+                 << "cp: " << currentOrderedPlotsInfo[i].at(2)
                  << ", "
-                 << "eg: " << std::tr1::get<0>(expectedOrderedPlotsInfo[i])
+                 << "eg: " << expectedOrderedPlotsInfo[i].at(0)
                  << ", "
-                 << "et: " << std::tr1::get<1>(expectedOrderedPlotsInfo[i])
+                 << "et: " << expectedOrderedPlotsInfo[i].at(1)
                  << ", "
-                 << "ep: " << std::tr1::get<2>(expectedOrderedPlotsInfo[i]);
+                 << "ep: " << expectedOrderedPlotsInfo[i].at(2);
     }
 
     for(int i = 0; i < expectedOrderedPlotsInfo.length(); ++i)
@@ -519,8 +519,8 @@ void Plots::changeOrder(QList<std::tr1::tuple<int, int> > orderedFilterInfo)
         Plot* plot = qobject_cast<Plot*> (plotItem->widget());
         Q_ASSERT(plot);
 
-        Q_ASSERT(plot->group() == std::tr1::get<0>(expectedOrderedPlotsInfo[row]) &&
-                 plot->type() == std::tr1::get<1>(expectedOrderedPlotsInfo[row]));
+        Q_ASSERT(plot->group() == expectedOrderedPlotsInfo[row].at(0) &&
+                 plot->type() == expectedOrderedPlotsInfo[row].at(1));
     }
 }
 

--- a/Source/GUI/Plots.h
+++ b/Source/GUI/Plots.h
@@ -15,6 +15,10 @@
 
 #include <QWidget>
 
+#ifndef _WIN32
+#include <tr1/tuple>
+#endif
+
 class QwtPlot;
 class Plot;
 class PlotScaleWidget;
@@ -97,7 +101,7 @@ public:
 
     virtual bool                eventFilter( QObject *, QEvent * );
     void                        adjustGroupMax(int group, int bitsPerRawSample);
-    void                        changeOrder(QList<std::tuple<int, int>> filterSelectorsInfo);
+    void                        changeOrder(QList<std::tr1::tuple<int, int> > filterSelectorsInfo);
 
 public Q_SLOTS:
     void                        onCurrentFrameChanged();

--- a/Source/GUI/Plots.h
+++ b/Source/GUI/Plots.h
@@ -15,10 +15,6 @@
 
 #include <QWidget>
 
-#ifndef _WIN32
-#include <tr1/tuple>
-#endif
-
 class QwtPlot;
 class Plot;
 class PlotScaleWidget;
@@ -101,7 +97,7 @@ public:
 
     virtual bool                eventFilter( QObject *, QEvent * );
     void                        adjustGroupMax(int group, int bitsPerRawSample);
-    void                        changeOrder(QList<std::tr1::tuple<int, int> > filterSelectorsInfo);
+    void                        changeOrder(QList<QPair<int, int> > filterSelectorsInfo);
 
 public Q_SLOTS:
     void                        onCurrentFrameChanged();

--- a/Source/GUI/SelectionArea.h
+++ b/Source/GUI/SelectionArea.h
@@ -2,6 +2,7 @@
 #define AIRUBBERBAND_H
 
 #include <QRubberBand>
+#include <QtGlobal>
 
 class SelectionArea : public QWidget
 {
@@ -22,7 +23,7 @@ public:
 		hitLeft = 7, 
 		hitMiddle = 8
 	};
-    Q_ENUM(TrackerHit);
+    Q_ENUMS(TrackerHit);
 
 public Q_SLOTS:
     void setMaxSize(int width, int height);

--- a/Source/GUI/draggablechildrenbehaviour.cpp
+++ b/Source/GUI/draggablechildrenbehaviour.cpp
@@ -19,9 +19,10 @@ DraggableChildrenBehaviour::DraggableChildrenBehaviour(QBoxLayout *layout) : QOb
     dropIndicator->setFrameShape(isHorizontalLayout() ? QFrame::VLine : QFrame::HLine);
     dropIndicator->hide();
 
-    for(auto child : parent->children())
+    QObjectList::const_iterator child;
+    for(child = parent->children().begin(); child != parent->children().end(); ++child)
     {
-        child->installEventFilter(this);
+        (*child)->installEventFilter(this);
     }
 }
 
@@ -29,7 +30,7 @@ void DraggableChildrenBehaviour::newDrag(QWidget *watched)
 {
     QDrag *drag = new QDrag(this);
 
-    auto mimeData = new QMimeData();
+    QMimeData* mimeData = new QMimeData();
     const QByteArray data = QByteArray::number((quintptr)watched);
 
     mimeData->setData(draggableMimeType, data);
@@ -45,21 +46,21 @@ bool DraggableChildrenBehaviour::eventFilter(QObject *watched, QEvent *event)
     {
         if(event->type() == QEvent::ChildAdded)
         {
-            auto addedChild = static_cast<QChildEvent*> (event)->child();
-            auto addedChildWidget = qobject_cast<QWidget*>(addedChild);
+            QObject* addedChild = static_cast<QChildEvent*> (event)->child();
+            QWidget* addedChildWidget = qobject_cast<QWidget*>(addedChild);
 
             if(addedChildWidget)
                 addedChildWidget->installEventFilter(this);
         }
         else if(event->type() == QEvent::DragEnter)
         {
-            auto dragEnterEvent = static_cast<QDragEnterEvent*> (event);
+            QDragEnterEvent* dragEnterEvent = static_cast<QDragEnterEvent*> (event);
             if(dragEnterEvent->mimeData()->hasFormat(draggableMimeType))
                 dragEnterEvent->accept();
         }
         else if(event->type() == QEvent::DragMove)
         {
-            auto dragMoveEvent = static_cast<QDragMoveEvent*> (event);
+            QDragMoveEvent* dragMoveEvent = static_cast<QDragMoveEvent*> (event);
 
             QWidget *child = parent->childAt(dragMoveEvent->pos());
             while(child && layout->indexOf(child) == -1)
@@ -70,7 +71,7 @@ bool DraggableChildrenBehaviour::eventFilter(QObject *watched, QEvent *event)
             if(child)
             {
                 int newDropIndex = layout->indexOf(child);
-                auto centerOfChild = child->geometry().center();
+                QPoint centerOfChild = child->geometry().center();
 
                 qDebug() << "pos: " << dragMoveEvent->pos() << ", child.center: " << centerOfChild << ", newDropIndex: " << newDropIndex;
 
@@ -104,7 +105,7 @@ bool DraggableChildrenBehaviour::eventFilter(QObject *watched, QEvent *event)
             }
         } else if(event->type() == QEvent::DragLeave)
         {
-            auto dragLeaveEvent = static_cast<QDragLeaveEvent*> (event);
+            QDragLeaveEvent* dragLeaveEvent = static_cast<QDragLeaveEvent*> (event);
 
             layout->removeWidget(dropIndicator);
             dropIndicator->hide();
@@ -112,7 +113,7 @@ bool DraggableChildrenBehaviour::eventFilter(QObject *watched, QEvent *event)
 
         } else if(event->type() == QEvent::Drop)
         {
-            auto dropEvent = static_cast<QDropEvent*> (event);
+            QDropEvent* dropEvent = static_cast<QDropEvent*> (event);
 
             const QByteArray data = dropEvent->mimeData()->data(draggableMimeType);
             QWidget* draggingWidget = reinterpret_cast<QWidget*> (data.toULongLong());

--- a/Source/GUI/imagelabel.h
+++ b/Source/GUI/imagelabel.h
@@ -41,6 +41,9 @@ public Q_SLOTS:
     void setSelectionArea(double x, double y, double w, double h);
     void showDebugOverlay(bool enable);
 
+    void geometryChangeFinished();
+    void geometryChanged(const QRect& geometry);
+
 Q_SIGNALS:
 
     void selectionChanged(const QRectF& geometry);

--- a/Source/GUI/mainwindow.cpp
+++ b/Source/GUI/mainwindow.cpp
@@ -35,9 +35,9 @@
 //***************************************************************************
 
 //---------------------------------------------------------------------------
-QList<std::tr1::tuple<int, int> > MainWindow::getFilterSelectorsOrder(int start = 0, int end = -1)
+QList<QPair<int, int> > MainWindow::getFilterSelectorsOrder(int start = 0, int end = -1)
 {
-    QList<std::tr1::tuple<int, int> > filtersInfo;
+    QList<QPair<int, int> > filtersInfo;
     if(end == -1)
         end = ui->horizontalLayout->count() - 1;
 
@@ -47,7 +47,7 @@ QList<std::tr1::tuple<int, int> > MainWindow::getFilterSelectorsOrder(int start 
         int group = o->property("group").toInt();
         int type = o->property("type").toInt();
 
-        filtersInfo.push_back(std::tr1::make_tuple(group, type));
+        filtersInfo.push_back(qMakePair(group, type));
     }
 
     return filtersInfo;
@@ -545,7 +545,7 @@ void MainWindow::positionChanged(QWidget* child, int oldPos, int newPos)
         end = oldPos;
     }
 
-    QList<std::tr1::tuple<int, int> > filtersSelectors = getFilterSelectorsOrder();
+    QList<QPair<int, int> > filtersSelectors = getFilterSelectorsOrder();
 
     if(PlotsArea)
         PlotsArea->changeOrder(filtersSelectors);

--- a/Source/GUI/mainwindow.cpp
+++ b/Source/GUI/mainwindow.cpp
@@ -35,19 +35,19 @@
 //***************************************************************************
 
 //---------------------------------------------------------------------------
-QList<std::tuple<int, int>> MainWindow::getFilterSelectorsOrder(int start = 0, int end = -1)
+QList<std::tr1::tuple<int, int> > MainWindow::getFilterSelectorsOrder(int start = 0, int end = -1)
 {
-    QList<std::tuple<int, int>> filtersInfo;
+    QList<std::tr1::tuple<int, int> > filtersInfo;
     if(end == -1)
         end = ui->horizontalLayout->count() - 1;
 
     for(int i = start; i <= end; ++i)
     {
-        auto o = ui->horizontalLayout->itemAt(i)->widget();
-        auto group = o->property("group").toInt();
-        auto type = o->property("type").toInt();
+        QWidget* o = ui->horizontalLayout->itemAt(i)->widget();
+        int group = o->property("group").toInt();
+        int type = o->property("type").toInt();
 
-        filtersInfo.push_back(std::make_tuple(group, type));
+        filtersInfo.push_back(std::tr1::make_tuple(group, type));
     }
 
     return filtersInfo;
@@ -87,24 +87,7 @@ MainWindow::MainWindow(QWidget *parent) :
     DeckRunning=false;
 
     draggableBehaviour = new DraggableChildrenBehaviour(ui->horizontalLayout);
-    connect(draggableBehaviour, &DraggableChildrenBehaviour::childPositionChanged, [&](QWidget* child, int oldPos, int newPos) {
-
-        Q_UNUSED(child);
-
-        int start = oldPos;
-        int end = newPos;
-
-        if(oldPos > newPos)
-        {
-            start = newPos;
-            end = oldPos;
-        }
-
-        QList<std::tuple<int, int>> filtersSelectors = getFilterSelectorsOrder();
-
-        if(PlotsArea)
-            PlotsArea->changeOrder(filtersSelectors);
-    });
+    connect(draggableBehaviour, SIGNAL(childPositionChanged(QWidget*, int, int)), this, SLOT(positionChanged(QWidget*, int, int)));
 }
 
 //---------------------------------------------------------------------------
@@ -547,4 +530,23 @@ void MainWindow::on_actionPlay_All_Frames_triggered()
 {
     if(ControlArea)
         ControlArea->setPlayAllFrames(true);
+}
+
+void MainWindow::positionChanged(QWidget* child, int oldPos, int newPos)
+{
+    Q_UNUSED(child);
+
+    int start = oldPos;
+    int end = newPos;
+
+    if(oldPos > newPos)
+    {
+        start = newPos;
+        end = oldPos;
+    }
+
+    QList<std::tr1::tuple<int, int> > filtersSelectors = getFilterSelectorsOrder();
+
+    if(PlotsArea)
+        PlotsArea->changeOrder(filtersSelectors);
 }

--- a/Source/GUI/mainwindow.h
+++ b/Source/GUI/mainwindow.h
@@ -15,10 +15,6 @@
 
 #include <vector>
 
-#ifndef _WIN32
-#include <tr1/tuple>
-#endif
-
 using namespace std;
 
 #include "Core/Core.h"
@@ -119,7 +115,7 @@ public:
     //Preferences
     Preferences*                Prefs;
 
-    QList<std::tr1::tuple<int, int> > getFilterSelectorsOrder(int start, int end);
+    QList<QPair<int, int> > getFilterSelectorsOrder(int start, int end);
 public Q_SLOTS:
 	void Update();
 
@@ -217,7 +213,7 @@ private:
     void updateScrollBar( bool blockSignals = false );
     bool isPlotZoomable() const;
     void Zoom( bool );
-    void changeFilterSelectorsOrder(QList<std::tr1::tuple<int, int> > filtersInfo);
+    void changeFilterSelectorsOrder(QList<QPair<int, int> > filtersInfo);
 
     DraggableChildrenBehaviour* draggableBehaviour;
 

--- a/Source/GUI/mainwindow.h
+++ b/Source/GUI/mainwindow.h
@@ -14,6 +14,11 @@
 #include <QMutex>
 
 #include <vector>
+
+#ifndef _WIN32
+#include <tr1/tuple>
+#endif
+
 using namespace std;
 
 #include "Core/Core.h"
@@ -113,8 +118,8 @@ public:
 
     //Preferences
     Preferences*                Prefs;
-    
-    QList<std::tuple<int, int>> getFilterSelectorsOrder(int start, int end);
+
+    QList<std::tr1::tuple<int, int> > getFilterSelectorsOrder(int start, int end);
 public Q_SLOTS:
 	void Update();
 
@@ -206,11 +211,13 @@ private Q_SLOTS:
 
     void on_actionPlay_All_Frames_triggered();
 
+    void positionChanged(QWidget* child, int oldPos, int newPos);
+
 private:
     void updateScrollBar( bool blockSignals = false );
     bool isPlotZoomable() const;
     void Zoom( bool );
-    void changeFilterSelectorsOrder(QList<std::tuple<int, int> > filtersInfo);
+    void changeFilterSelectorsOrder(QList<std::tr1::tuple<int, int> > filtersInfo);
 
     DraggableChildrenBehaviour* draggableBehaviour;
 

--- a/Source/GUI/mainwindow_More.cpp
+++ b/Source/GUI/mainwindow_More.cpp
@@ -74,11 +74,11 @@ void MainWindow::openCapture()
         DeckRunning=false;
         return;
     }
-        
+
     BlackmagicDeckLink_UserInput* blackmagicDeckLink_UserInput=new BlackmagicDeckLink_UserInput();
     if (!blackmagicDeckLink_UserInput->exec())
         return;
-    
+
     clearFiles();
     addFile(blackmagicDeckLink_UserInput->Card, blackmagicDeckLink_UserInput->Card->Config_In.FrameCount, blackmagicDeckLink_UserInput->Encoding_FileName.toUtf8().data(), blackmagicDeckLink_UserInput->Encoding_Format.toUtf8().data());
     addFile_finish();
@@ -324,7 +324,7 @@ void MainWindow::createGraphsLayout()
 
     PlotsArea=Files[Files_CurrentPos]->Stats.empty()?NULL:new Plots(this, Files[Files_CurrentPos]);
 
-    QList<std::tr1::tuple<int, int> > filtersInfo = Prefs->loadFilterSelectorsOrder();
+    QList<QPair<int, int> > filtersInfo = Prefs->loadFilterSelectorsOrder();
     changeFilterSelectorsOrder(filtersInfo);
     if (PlotsArea)
     {

--- a/Source/GUI/mainwindow_More.cpp
+++ b/Source/GUI/mainwindow_More.cpp
@@ -324,7 +324,7 @@ void MainWindow::createGraphsLayout()
 
     PlotsArea=Files[Files_CurrentPos]->Stats.empty()?NULL:new Plots(this, Files[Files_CurrentPos]);
 
-    auto filtersInfo = Prefs->loadFilterSelectorsOrder();
+    QList<std::tr1::tuple<int, int> > filtersInfo = Prefs->loadFilterSelectorsOrder();
     changeFilterSelectorsOrder(filtersInfo);
     if (PlotsArea)
     {
@@ -343,7 +343,7 @@ void MainWindow::createGraphsLayout()
     ControlArea=new Control(this, Files[Files_CurrentPos], Control::Style_Cols);
     ControlArea->setPlayAllFrames(ui->actionPlay_All_Frames->isChecked());
 
-    connect( ControlArea, SIGNAL( currentFrameChanged() ), 
+    connect( ControlArea, SIGNAL( currentFrameChanged() ),
         this, SLOT( on_CurrentFrameChanged() ) );
 
     if (!ui->actionGraphsLayout->isChecked())

--- a/Source/GUI/mainwindow_Ui.cpp
+++ b/Source/GUI/mainwindow_Ui.cpp
@@ -242,34 +242,36 @@ void MainWindow::Zoom( bool on )
     configureZoom();
 }
 
-void MainWindow::changeFilterSelectorsOrder(QList<std::tuple<int, int> > filtersInfo)
+void MainWindow::changeFilterSelectorsOrder(QList<std::tr1::tuple<int, int> > filtersInfo)
 {
     QSignalBlocker blocker(draggableBehaviour);
 
-    auto boxlayout = static_cast<QHBoxLayout*> (ui->horizontalLayout);
+    QHBoxLayout* boxlayout = static_cast<QHBoxLayout*> (ui->horizontalLayout);
 
     QList<QLayoutItem*> items;
 
-    for(std::tuple<int, int> groupAndType : filtersInfo)
+    QList<std::tr1::tuple<int, int> >::iterator groupAndType;
+    for(groupAndType = filtersInfo.begin(); groupAndType != filtersInfo.end(); ++groupAndType)
     {
-        int group = std::get<0>(groupAndType);
-        int type = std::get<1>(groupAndType);
+        int group = std::tr1::get<0>(*groupAndType);
+        int type = std::tr1::get<1>(*groupAndType);
 
-        auto rowsCount = boxlayout->count();
-        for(auto row = 0; row < rowsCount; ++row)
+        int rowsCount = boxlayout->count();
+        for(int row = 0; row < rowsCount; ++row)
         {
-            auto checkboxItem = boxlayout->itemAt(row);
+            QLayoutItem* checkboxItem = boxlayout->itemAt(row);
             if(checkboxItem->widget()->property("group") == group && checkboxItem->widget()->property("type") == type)
             {
                 items.append(boxlayout->takeAt(row));
                 break;
             }
         }
-    };
+    }
 
-    for(auto item : items)
+    QList<QLayoutItem*>::iterator item;
+    for(item = items.begin(); item != items.end(); ++item)
     {
-        boxlayout->addItem(item);
+        boxlayout->addItem(*item);
     }
 }
 
@@ -326,7 +328,7 @@ void MainWindow::Export_PDF()
 
     /*
     QwtPlotRenderer PlotRenderer;
-    PlotRenderer.renderDocument(const_cast<QwtPlot*>( PlotsArea->plot(TempType, Group_Y) ), 
+    PlotRenderer.renderDocument(const_cast<QwtPlot*>( PlotsArea->plot(TempType, Group_Y) ),
         SaveFileName, "PDF", QSizeF(210, 297), 150);
     QDesktopServices::openUrl(QUrl("file:///"+SaveFileName, QUrl::TolerantMode));
     */

--- a/Source/GUI/mainwindow_Ui.cpp
+++ b/Source/GUI/mainwindow_Ui.cpp
@@ -242,7 +242,7 @@ void MainWindow::Zoom( bool on )
     configureZoom();
 }
 
-void MainWindow::changeFilterSelectorsOrder(QList<std::tr1::tuple<int, int> > filtersInfo)
+void MainWindow::changeFilterSelectorsOrder(QList<QPair<int, int> > filtersInfo)
 {
     QSignalBlocker blocker(draggableBehaviour);
 
@@ -250,11 +250,11 @@ void MainWindow::changeFilterSelectorsOrder(QList<std::tr1::tuple<int, int> > fi
 
     QList<QLayoutItem*> items;
 
-    QList<std::tr1::tuple<int, int> >::iterator groupAndType;
+    QList<QPair<int, int> >::iterator groupAndType;
     for(groupAndType = filtersInfo.begin(); groupAndType != filtersInfo.end(); ++groupAndType)
     {
-        int group = std::tr1::get<0>(*groupAndType);
-        int type = std::tr1::get<1>(*groupAndType);
+        int group = groupAndType->first;
+        int type = groupAndType->second;
 
         int rowsCount = boxlayout->count();
         for(int row = 0; row < rowsCount; ++row)

--- a/Source/GUI/preferences.cpp
+++ b/Source/GUI/preferences.cpp
@@ -13,7 +13,7 @@
 #include <QDebug>
 //---------------------------------------------------------------------------
 
-typedef std::tuple<int, int> GroupAndType;
+typedef std::tr1::tuple<int, int> GroupAndType;
 Q_DECLARE_METATYPE(GroupAndType)
 
 typedef QList<GroupAndType> FilterSelectorsOrder;
@@ -56,12 +56,15 @@ QDataStream &operator<<(QDataStream &out, const FilterSelectorsOrder &order) {
 
     qDebug() << "serializing total " << order.length() << ": \n";
 
-    for(auto item : order) {
-        qDebug() << "g: " << std::get<0>(item) << ", t: " << std::get<1>(item);;
+    FilterSelectorsOrder::const_iterator item;
+    for(item = order.begin(); item != order.end(); ++item) {
+        qDebug() << "g: " << std::tr1::get<0>(*item) << ", t: " << std::tr1::get<1>(*item);
     }
 
-    for(auto filterInfo : order)
-        out << std::get<0>(filterInfo) << std::get<1>(filterInfo);
+    FilterSelectorsOrder::const_iterator filterInfo;
+    for(filterInfo = order.begin(); filterInfo != order.end(); ++filterInfo) {
+        out << std::tr1::get<0>(*filterInfo) << std::tr1::get<1>(*filterInfo);
+    }
 
     return out;
 }
@@ -73,30 +76,31 @@ QDataStream &operator>>(QDataStream &in, FilterSelectorsOrder &order) {
         in >> group;
         in >> type;
 
-        auto entry = std::make_tuple(group, type);
+        std::tr1::tuple<int, int> entry = std::tr1::make_tuple(group, type);
         if(!order.contains(entry))
             order.push_back(entry);
     }
 
     qDebug() << "deserialized: total " << order.length() << "\n";
 
-    for(auto item : order) {
-        qDebug() << "g: " << std::get<0>(item) << ", t: " << std::get<1>(item);
+    FilterSelectorsOrder::iterator item;
+    for(item = order.begin(); item != order.end(); ++item) {
+        qDebug() << "g: " << std::tr1::get<0>(*item) << ", t: " << std::tr1::get<1>(*item);
     }
 
     return in;
 }
 
-QList<std::tuple<int, int> > Preferences::loadFilterSelectorsOrder()
+QList<std::tr1::tuple<int, int> > Preferences::loadFilterSelectorsOrder()
 {
     QSettings Settings;
 
-    auto order = Settings.value("filterSelectorsOrder", QVariant::fromValue(FilterSelectorsOrder())).value<FilterSelectorsOrder>();
+    QList<std::tr1::tuple<int, int> > order = Settings.value("filterSelectorsOrder", QVariant::fromValue(FilterSelectorsOrder())).value<FilterSelectorsOrder>();
 
     return order;
 }
 
-void Preferences::saveFilterSelectorsOrder(const QList<std::tuple<int, int> > &order)
+void Preferences::saveFilterSelectorsOrder(const QList<std::tr1::tuple<int, int> > &order)
 {
     QSettings Settings;
 

--- a/Source/GUI/preferences.cpp
+++ b/Source/GUI/preferences.cpp
@@ -13,7 +13,7 @@
 #include <QDebug>
 //---------------------------------------------------------------------------
 
-typedef std::tr1::tuple<int, int> GroupAndType;
+typedef QPair<int, int> GroupAndType;
 Q_DECLARE_METATYPE(GroupAndType)
 
 typedef QList<GroupAndType> FilterSelectorsOrder;
@@ -58,12 +58,12 @@ QDataStream &operator<<(QDataStream &out, const FilterSelectorsOrder &order) {
 
     FilterSelectorsOrder::const_iterator item;
     for(item = order.begin(); item != order.end(); ++item) {
-        qDebug() << "g: " << std::tr1::get<0>(*item) << ", t: " << std::tr1::get<1>(*item);
+        qDebug() << "g: " << item->first << ", t: " << item->second;
     }
 
     FilterSelectorsOrder::const_iterator filterInfo;
     for(filterInfo = order.begin(); filterInfo != order.end(); ++filterInfo) {
-        out << std::tr1::get<0>(*filterInfo) << std::tr1::get<1>(*filterInfo);
+        out << filterInfo->first << filterInfo->second;
     }
 
     return out;
@@ -76,7 +76,7 @@ QDataStream &operator>>(QDataStream &in, FilterSelectorsOrder &order) {
         in >> group;
         in >> type;
 
-        std::tr1::tuple<int, int> entry = std::tr1::make_tuple(group, type);
+        QPair<int, int> entry = qMakePair(group, type);
         if(!order.contains(entry))
             order.push_back(entry);
     }
@@ -85,22 +85,22 @@ QDataStream &operator>>(QDataStream &in, FilterSelectorsOrder &order) {
 
     FilterSelectorsOrder::iterator item;
     for(item = order.begin(); item != order.end(); ++item) {
-        qDebug() << "g: " << std::tr1::get<0>(*item) << ", t: " << std::tr1::get<1>(*item);
+        qDebug() << "g: " << item->first << ", t: " << item->second;
     }
 
     return in;
 }
 
-QList<std::tr1::tuple<int, int> > Preferences::loadFilterSelectorsOrder()
+QList<QPair<int, int> > Preferences::loadFilterSelectorsOrder()
 {
     QSettings Settings;
 
-    QList<std::tr1::tuple<int, int> > order = Settings.value("filterSelectorsOrder", QVariant::fromValue(FilterSelectorsOrder())).value<FilterSelectorsOrder>();
+    QList<QPair<int, int> > order = Settings.value("filterSelectorsOrder", QVariant::fromValue(FilterSelectorsOrder())).value<FilterSelectorsOrder>();
 
     return order;
 }
 
-void Preferences::saveFilterSelectorsOrder(const QList<std::tr1::tuple<int, int> > &order)
+void Preferences::saveFilterSelectorsOrder(const QList<QPair<int, int> > &order)
 {
     QSettings Settings;
 

--- a/Source/GUI/preferences.h
+++ b/Source/GUI/preferences.h
@@ -5,10 +5,6 @@
 #include <QDialog>
 #include <QList>
 
-#ifndef _WIN32
-#include <tr1/tuple>
-#endif
-
 namespace Ui {
 class Preferences;
 }
@@ -25,8 +21,8 @@ public:
     activefilters ActiveFilters;
     activealltracks ActiveAllTracks;
 
-    QList<std::tr1::tuple<int, int> > loadFilterSelectorsOrder();
-    void saveFilterSelectorsOrder(const QList<std::tr1::tuple<int, int> >& order);
+    QList<QPair<int, int> > loadFilterSelectorsOrder();
+    void saveFilterSelectorsOrder(const QList<QPair<int, int> >& order);
 
 private:
     Ui::Preferences *ui;

--- a/Source/GUI/preferences.h
+++ b/Source/GUI/preferences.h
@@ -4,7 +4,10 @@
 #include "Core/Core.h"
 #include <QDialog>
 #include <QList>
-#include <tuple>
+
+#ifndef _WIN32
+#include <tr1/tuple>
+#endif
 
 namespace Ui {
 class Preferences;
@@ -22,8 +25,8 @@ public:
     activefilters ActiveFilters;
     activealltracks ActiveAllTracks;
 
-    QList<std::tuple<int, int>> loadFilterSelectorsOrder();
-    void saveFilterSelectorsOrder(const QList<std::tuple<int, int>>& order);
+    QList<std::tr1::tuple<int, int> > loadFilterSelectorsOrder();
+    void saveFilterSelectorsOrder(const QList<std::tr1::tuple<int, int> >& order);
 
 private:
     Ui::Preferences *ui;


### PR DESCRIPTION
C++11 code prevents us to use C++03 compilers and libraries.
This is a blocker for providing binaries for old Linux distribution versions (they contain a too old GCC) and for a macOS binary compatible with 10.6 (10.6 does not contain a libc++ compatible with C++11).