### PR TITLE
Qt4 compatibility

### DIFF
--- a/Source/GUI/BigDisplay.h
+++ b/Source/GUI/BigDisplay.h
@@ -83,6 +83,14 @@ private:
 public Q_SLOTS:
     void on_valueChanged(double);
     void on_sliderMoved(int);
+    void selectionChangedX(const QRectF& geometry);
+    void selectionChangedY(const QRectF& geometry);
+    void selectionChangedWidth(const QRectF& geometry);
+    void selectionChangedHeight(const QRectF& geometry);
+    void selectionChangeFinishedX(const QRectF& geometry);
+    void selectionChangeFinishedY(const QRectF& geometry);
+    void selectionChangeFinishedWidth(const QRectF& geometry);
+    void selectionChangeFinishedHeight(const QRectF& geometry);
 
 Q_SIGNALS:
     void controlValueChanged(double);
@@ -95,6 +103,11 @@ Q_SIGNALS:
 class BigDisplay : public QDialog
 {
     Q_OBJECT
+
+#if QT_VERSION < 0x050200
+private:
+    bool                        Stop;
+#endif
 
 public:
     // Constructor/Destructor
@@ -190,6 +203,9 @@ public Q_SLOTS:
     void on_Color2_click(bool checked);
 
     void on_Full_triggered();
+#if QT_VERSION < 0x050200
+    void interruptionRequested();
+#endif
 };
 
 #endif // GUI_BigDisplay_H

--- a/Source/GUI/Control.cpp
+++ b/Source/GUI/Control.cpp
@@ -219,9 +219,15 @@ void Control::stop()
 {
     if(Thread)
     {
+#if QT_VERSION >= 0x050200
         qDebug() << "Thread->requestInterruption()";
         Thread->requestInterruption();
-
+#else
+        if (TinyDisplayArea && TinyDisplayArea->BigDisplayArea)
+        {
+            QMetaObject::invokeMethod(TinyDisplayArea->BigDisplayArea, "interruptionRequested", Qt::QueuedConnection);
+        }
+#endif
         qDebug() << "qApp->processEvents()";
         qApp->processEvents();
 

--- a/Source/GUI/SelectionArea.h
+++ b/Source/GUI/SelectionArea.h
@@ -12,17 +12,21 @@ public:
 
     enum TrackerHit {
 		hitNothing = -1,
-		hitTopLeft = 0, 
-		hitTopRight = 1, 
-		hitBottomRight = 2, 
+		hitTopLeft = 0,
+		hitTopRight = 1,
+		hitBottomRight = 2,
 		hitBottomLeft = 3,
-		hitTop = 4, 
-		hitRight = 5, 
-		hitBottom = 6, 
-		hitLeft = 7, 
+		hitTop = 4,
+		hitRight = 5,
+		hitBottom = 6,
+		hitLeft = 7,
 		hitMiddle = 8
 	};
+#if QT_VERSION >= QT_VERSION_CHECK(5, 5, 0)
     Q_ENUM(TrackerHit);
+#else
+    Q_ENUMS(TrackerHit);
+#endif
 
 public Q_SLOTS:
     void setMaxSize(int width, int height);

--- a/Source/GUI/TinyDisplay.cpp
+++ b/Source/GUI/TinyDisplay.cpp
@@ -50,7 +50,8 @@ TinyDisplay::TinyDisplay(QWidget *parent, FileInformation* FileInformationData_)
 TinyDisplay::~TinyDisplay()
 {
     while (!thumbnails.empty()) {
-        QToolButton *t = thumbnails.takeLast();
+        QToolButton *t = thumbnails.last();
+        thumbnails.pop_back();
         delete t;
     }
 
@@ -94,7 +95,8 @@ void TinyDisplay::thumbsLayoutResized()
         else if (total_thumbs < thumbnails.size()) {
             int diff = thumbnails.size() - total_thumbs;
             for (int i = 0; i < diff; ++i) {
-                QToolButton *tool_button = thumbnails.takeLast();
+                QToolButton *tool_button = thumbnails.last();
+                thumbnails.pop_back();
                 disconnect(tool_button, 0, 0, 0);
                 Layout->removeWidget(tool_button);
                 delete tool_button;

--- a/Source/GUI/draggablechildrenbehaviour.cpp
+++ b/Source/GUI/draggablechildrenbehaviour.cpp
@@ -27,7 +27,11 @@ DraggableChildrenBehaviour::DraggableChildrenBehaviour(QBoxLayout *layout) : QOb
 
 void DraggableChildrenBehaviour::newDrag(QWidget *watched)
 {
+#if QT_VERSION >= 0x050000
     QDrag *drag = new QDrag(this);
+#else
+    QDrag *drag = new QDrag(watched);
+#endif
 
     auto mimeData = new QMimeData();
     const QByteArray data = QByteArray::number((quintptr)watched);

--- a/Source/GUI/imagelabel.h
+++ b/Source/GUI/imagelabel.h
@@ -41,6 +41,9 @@ public Q_SLOTS:
     void setSelectionArea(double x, double y, double w, double h);
     void showDebugOverlay(bool enable);
 
+    void geometryChangeFinished();
+    void geometryChanged(const QRect& geometry);
+
 Q_SIGNALS:
 
     void selectionChanged(const QRectF& geometry);

--- a/Source/GUI/main.cpp
+++ b/Source/GUI/main.cpp
@@ -9,8 +9,11 @@
 #include <QtPlugin>
 #include <iostream>
 
+#if defined(_WIN32) && !defined(_DLL)
+    #include <QtPlugin>
+    Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin)
+#endif
 
-#include <QtCore/QtPlugin>
 #ifdef __MACOSX__
     #include <ApplicationServices/ApplicationServices.h>
 #endif //__MACOSX__

--- a/Source/GUI/mainwindow.cpp
+++ b/Source/GUI/mainwindow.cpp
@@ -87,24 +87,7 @@ MainWindow::MainWindow(QWidget *parent) :
     DeckRunning=false;
 
     draggableBehaviour = new DraggableChildrenBehaviour(ui->horizontalLayout);
-    connect(draggableBehaviour, &DraggableChildrenBehaviour::childPositionChanged, [&](QWidget* child, int oldPos, int newPos) {
-
-        Q_UNUSED(child);
-
-        int start = oldPos;
-        int end = newPos;
-
-        if(oldPos > newPos)
-        {
-            start = newPos;
-            end = oldPos;
-        }
-
-        QList<std::tuple<int, int>> filtersSelectors = getFilterSelectorsOrder();
-
-        if(PlotsArea)
-            PlotsArea->changeOrder(filtersSelectors);
-    });
+    connect(draggableBehaviour, SIGNAL(childPositionChanged(QWidget*, int, int)), this, SLOT(positionChanged(QWidget*, int, int)));
 }
 
 //---------------------------------------------------------------------------
@@ -547,4 +530,23 @@ void MainWindow::on_actionPlay_All_Frames_triggered()
 {
     if(ControlArea)
         ControlArea->setPlayAllFrames(true);
+}
+
+void MainWindow::positionChanged(QWidget* child, int oldPos, int newPos)
+{
+    Q_UNUSED(child);
+
+    int start = oldPos;
+    int end = newPos;
+
+    if(oldPos > newPos)
+    {
+        start = newPos;
+        end = oldPos;
+    }
+
+    QList<std::tuple<int, int> > filtersSelectors = getFilterSelectorsOrder();
+
+    if(PlotsArea)
+        PlotsArea->changeOrder(filtersSelectors);
 }

--- a/Source/GUI/mainwindow.h
+++ b/Source/GUI/mainwindow.h
@@ -113,8 +113,8 @@ public:
 
     //Preferences
     Preferences*                Prefs;
-    
-    QList<std::tuple<int, int>> getFilterSelectorsOrder(int start, int end);
+
+    QList<std::tuple<int, int> > getFilterSelectorsOrder(int start, int end);
 public Q_SLOTS:
 	void Update();
 
@@ -205,6 +205,8 @@ private Q_SLOTS:
     void on_actionPlay_at_Frame_Rate_triggered();
 
     void on_actionPlay_All_Frames_triggered();
+
+    void positionChanged(QWidget* child, int oldPos, int newPos);
 
 private:
     void updateScrollBar( bool blockSignals = false );

--- a/Source/GUI/mainwindow_Ui.cpp
+++ b/Source/GUI/mainwindow_Ui.cpp
@@ -244,7 +244,7 @@ void MainWindow::Zoom( bool on )
 
 void MainWindow::changeFilterSelectorsOrder(QList<std::tuple<int, int> > filtersInfo)
 {
-    QSignalBlocker blocker(draggableBehaviour);
+    draggableBehaviour->blockSignals(true);
 
     auto boxlayout = static_cast<QHBoxLayout*> (ui->horizontalLayout);
 
@@ -271,6 +271,8 @@ void MainWindow::changeFilterSelectorsOrder(QList<std::tuple<int, int> > filters
     {
         boxlayout->addItem(item);
     }
+
+    draggableBehaviour->blockSignals(false);
 }
 
 void MainWindow::updateScrollBar( bool blockSignals )

--- a/Source/GUI/preferences.cpp
+++ b/Source/GUI/preferences.cpp
@@ -8,10 +8,8 @@
 #include "preferences.h"
 #include "ui_preferences.h"
 #include <QSettings>
-#include <QStandardPaths>
 #include <QMetaType>
 #include <QDebug>
-//---------------------------------------------------------------------------
 
 typedef std::tuple<int, int> GroupAndType;
 Q_DECLARE_METATYPE(GroupAndType)


### PR DESCRIPTION
We try to keep the availability of QCTools for old Linux distributions, and they don't have Qt5.

We propose an update which:
- uses Qt4 version of a feature when it is directly available
- uses a workaround, without touching the Qt5 code ("#if QT_VERSION < 0x050200"), when this is more complex to handle