### PR TITLE
Uncompress stats file by chunks

### DIFF
--- a/Source/Core/AudioStats.cpp
+++ b/Source/Core/AudioStats.cpp
@@ -49,12 +49,12 @@ AudioStats::~AudioStats()
 //***************************************************************************
 
 //---------------------------------------------------------------------------
-void AudioStats::StatsFromExternalData (const string &Data)
+void AudioStats::StatsFromExternalData(const char* Data, size_t Size)
 {
     // AudioStats from external data
     // XML input
     XMLDocument Document;
-    if (Document.Parse(Data.c_str()))
+    if (Document.Parse(Data, Size))
        return;
 
     XMLElement* Root=Document.FirstChildElement("ffprobe:ffprobe");
@@ -178,9 +178,6 @@ void AudioStats::StatsFromExternalData (const string &Data)
             }
         }
     }
-
-    Frequency=1;
-    StatsFinish();
 }
 
 //---------------------------------------------------------------------------

--- a/Source/Core/AudioStats.h
+++ b/Source/Core/AudioStats.h
@@ -23,11 +23,11 @@ class AudioStats : public CommonStats
 {
 public:
     // Constructor / Destructor
-    AudioStats(size_t FrameCount=0, double Duration=0, AVStream* stream = nullptr);
+    AudioStats(size_t FrameCount=0, double Duration=0, AVStream* stream = NULL);
     ~AudioStats();
 
     // External data
-    void                        StatsFromExternalData(const string &Data);
+    void                        StatsFromExternalData(const char* Data, size_t Size);
     void                        StatsFromFrame(struct AVFrame* Frame, int Width, int Height);
     void                        TimeStampFromFrame(struct AVFrame* Frame, size_t FramePos);
     string                      StatsToCSV();

--- a/Source/Core/CommonStats.h
+++ b/Source/Core/CommonStats.h
@@ -21,7 +21,7 @@ class CommonStats
 {
 public:
     // Constructor / Destructor
-    CommonStats(const struct per_item* PerItem, int Type, size_t CountOfGroups, size_t CountOfItems, size_t FrameCount=0, double Duration=0, AVStream* stream = nullptr);
+    CommonStats(const struct per_item* PerItem, int Type, size_t CountOfGroups, size_t CountOfItems, size_t FrameCount=0, double Duration=0, AVStream* stream = NULL);
     virtual ~CommonStats();
 
     // Data
@@ -49,7 +49,8 @@ public:
     string                      Percent_Get(size_t Pos);
 
     // External data
-    virtual void                StatsFromExternalData(const string &Data) = 0;
+    virtual void                StatsFromExternalData(const char* Data, size_t Size) = 0;
+            void                StatsFromExternalData_Finish() {Frequency=1; StatsFinish();}
     virtual void                StatsFromFrame(struct AVFrame* Frame, int Width, int Height) = 0;
     virtual void                TimeStampFromFrame(struct AVFrame* Frame, size_t FramePos) = 0;
     virtual void                StatsFinish();

--- a/Source/Core/VideoStats.cpp
+++ b/Source/Core/VideoStats.cpp
@@ -49,12 +49,12 @@ VideoStats::~VideoStats()
 //***************************************************************************
 
 //---------------------------------------------------------------------------
-void VideoStats::StatsFromExternalData (const string &Data)
+void VideoStats::StatsFromExternalData (const char* Data, size_t Size)
 {
     // VideoStats from external data
     // XML input
     XMLDocument Document;
-    if (Document.Parse(Data.c_str()))
+    if (Document.Parse(Data, Size))
        return;
 
     XMLElement* Root=Document.FirstChildElement("ffprobe:ffprobe");
@@ -203,9 +203,6 @@ void VideoStats::StatsFromExternalData (const string &Data)
             }
         }
     }
-
-    Frequency=1;
-    StatsFinish();
 }
 
 //---------------------------------------------------------------------------

--- a/Source/Core/VideoStats.h
+++ b/Source/Core/VideoStats.h
@@ -23,11 +23,11 @@ class VideoStats : public CommonStats
 {
 public:
     // Constructor / Destructor
-    VideoStats(size_t FrameCount=0, double Duration=0, AVStream* stream = nullptr);
+    VideoStats(size_t FrameCount=0, double Duration=0, AVStream* stream = NULL);
     ~VideoStats();
 
     // External data
-    void                        StatsFromExternalData(const string &Data);
+    void                        StatsFromExternalData(const char* Data, size_t Size);
     void                        StatsFromFrame(struct AVFrame* Frame, int Width, int Height);
     void                        TimeStampFromFrame(struct AVFrame* Frame, size_t FramePos);
     string                      StatsToCSV();

--- a/Source/GUI/FileInformation.cpp
+++ b/Source/GUI/FileInformation.cpp
@@ -142,51 +142,8 @@ FileInformation::FileInformation (MainWindow* Main_, const QString &FileName_, a
     }
 
     // External data optional input
-    string StatsFromExternalData;
-    if (!StatsFromExternalData_FileName.size()==0)
-    {
-        if (StatsFromExternalData_FileName_IsCompressed)
-        {
-            QFile F(StatsFromExternalData_FileName);
-            if (F.open(QIODevice::ReadOnly))
-            {
-                QByteArray Compressed=F.readAll();
-                uLongf Buffer_Size=0;
-                Buffer_Size|=((unsigned char)Compressed[Compressed.size()-1])<<24;
-                Buffer_Size|=((unsigned char)Compressed[Compressed.size()-2])<<16;
-                Buffer_Size|=((unsigned char)Compressed[Compressed.size()-3])<<8;
-                Buffer_Size|=((unsigned char)Compressed[Compressed.size()-4]);
-                char* Buffer=new char[Buffer_Size];
-                z_stream strm;
-                strm.next_in = (Bytef *) Compressed.data();
-                strm.avail_in = Compressed.size() ;
-                strm.next_out = (unsigned char*) Buffer;
-                strm.avail_out = Buffer_Size;
-                strm.total_out = 0;
-                strm.zalloc = Z_NULL;
-                strm.zfree = Z_NULL;
-                if (inflateInit2(&strm, 15 + 16)>=0) // 15 + 16 are magic values for gzip
-                {
-                    if (inflate(&strm, Z_SYNC_FLUSH)>=0)
-                    {
-                        inflateEnd (&strm);
-                        StatsFromExternalData.assign(Buffer, Buffer_Size);
-                    }
-                }
-                delete[] Buffer;
-            }
-        }
-        else
-        {
-            QFile F(StatsFromExternalData_FileName);
-            if (F.open(QIODevice::ReadOnly))
-            {
-                QByteArray Data=F.readAll();
-
-                StatsFromExternalData.assign(Data.data(), Data.size());
-            }
-        }
-    }
+    QFile StatsFromExternalData_File(StatsFromExternalData_FileName);
+    bool StatsFromExternalData_IsOpen=StatsFromExternalData_File.open(QIODevice::ReadOnly);
 
     // Running FFmpeg
     string FileName_string=FileName.toUtf8().data();
@@ -194,7 +151,7 @@ FileInformation::FileInformation (MainWindow* Main_, const QString &FileName_, a
         replace(FileName_string.begin(), FileName_string.end(), '/', '\\' );
     #endif
     string Filters[Type_Max];
-    if (StatsFromExternalData.empty())
+    if (!StatsFromExternalData_IsOpen)
     {
         if (ActiveFilters[ActiveFilter_Video_signalstats])
             Filters[0]+=",signalstats=stat=tout+vrep+brng";
@@ -222,13 +179,125 @@ FileInformation::FileInformation (MainWindow* Main_, const QString &FileName_, a
     }
     else
     {
+        //Stats init
         VideoStats* Video=new VideoStats();
         Stats.push_back(Video);
-        Video->StatsFromExternalData(StatsFromExternalData);
-
         AudioStats* Audio=new AudioStats();
         Stats.push_back(Audio);
-        Audio->StatsFromExternalData(StatsFromExternalData);
+
+        //XML init
+        const char*  Xml_HeaderFooter="</frames></ffprobe:ffprobe><ffprobe:ffprobe><frames>";
+        const size_t Xml_HeaderSize=25;
+        const size_t Xml_FooterSize=27;
+        const size_t Xml_MaxSize=0x1000000; //Blocks of 16 MiB, arbitrary chosen
+        char* Xml=new char[Xml_MaxSize+Xml_HeaderSize+Xml_FooterSize];
+
+        //Read init
+        const size_t Compressed_MaxSize=0x100000; //Blocks of 1 MiB, arbitrary chosen
+        char* Compressed=new char[Compressed_MaxSize];
+
+        //Uncompress init
+        z_stream strm;
+        if (StatsFromExternalData_FileName_IsCompressed)
+        {
+            strm.next_in = NULL;
+            strm.avail_in = 0;
+            strm.next_out = NULL;
+            strm.avail_out = 0;
+            strm.total_out = 0;
+            strm.zalloc = Z_NULL;
+            strm.zfree = Z_NULL;
+            inflateInit2(&strm, 15 + 16); // 15 + 16 are magic values for gzip
+        }
+
+        //Load and parse compressed data chunk by chunk
+        char* Xml_Pointer=Xml;
+        int inflate_Result;
+        int TEMP = 0;
+        for (;;)
+        {
+            //Load
+            qint64 ReadSize;
+            size_t avail_out=Xml_MaxSize-(Xml_Pointer-Xml);
+            if (StatsFromExternalData_FileName_IsCompressed)
+                ReadSize=StatsFromExternalData_File.read(Compressed, Compressed_MaxSize); //Load in an intermediate buffer for decompression
+            else
+                ReadSize=StatsFromExternalData_File.read(Xml_Pointer, avail_out); //Load directly in the XML buffer
+            if (!ReadSize)
+                break;
+            TEMP += ReadSize;
+
+            //Parse compressed data, with handling of the case the output buffer is not big enough
+            strm.next_in=(Bytef*)Compressed;
+            strm.avail_in=ReadSize;
+            for (;;)
+            {
+                size_t Xml_Size=Xml_Pointer-Xml;
+                if (StatsFromExternalData_FileName_IsCompressed)
+                {
+                    //inflate
+                    strm.next_out=(Bytef*)Xml_Pointer;
+                    strm.avail_out=avail_out;
+                    if ((inflate_Result=inflate(&strm, Z_NO_FLUSH))<0)
+                        break;
+                    Xml_Size+=avail_out-strm.avail_out;
+                }
+                else
+                    Xml_Size+=ReadSize;
+
+                //Cut the XML after the last XML frame footer, and keep the remaining data for the next turn
+                size_t Xml_SizeForParsing=Xml_Size;
+                //Look for XML frame footer
+                while (Xml_SizeForParsing>Xml_HeaderSize &&
+                        ( Xml[Xml_SizeForParsing-1]!='>' //"</frame>"
+                    || Xml[Xml_SizeForParsing-2]!='e'
+                    || Xml[Xml_SizeForParsing-3]!='m'
+                    || Xml[Xml_SizeForParsing-4]!='a'
+                    || Xml[Xml_SizeForParsing-5]!='r'
+                    || Xml[Xml_SizeForParsing-6]!='f'
+                    || Xml[Xml_SizeForParsing-7]!='/'
+                    || Xml[Xml_SizeForParsing-8]!='<'))
+                    Xml_SizeForParsing--;
+                if (Xml_SizeForParsing<=Xml_HeaderSize)
+                {
+                    //The block does not contain any complete frame, looping in order to get more data from the file
+                    Xml_Pointer=Xml+Xml_Size;
+                    break;
+                }
+
+                //Insert Xml_HeaderFooter inside the XML content
+                memmove(Xml+Xml_SizeForParsing+Xml_HeaderSize+Xml_FooterSize, Xml+Xml_SizeForParsing, Xml_Size-Xml_SizeForParsing);
+                memcpy(Xml+Xml_SizeForParsing, Xml_HeaderFooter, Xml_HeaderSize+Xml_FooterSize);
+                Xml_Size+=Xml_HeaderSize+Xml_FooterSize;
+                Xml_SizeForParsing+=Xml_FooterSize;
+
+                //Parse
+                Video->StatsFromExternalData(Xml, Xml_SizeForParsing);
+                Audio->StatsFromExternalData(Xml, Xml_SizeForParsing);
+
+                //Cut the parsed content
+                memmove(Xml, Xml+Xml_SizeForParsing, Xml_Size-Xml_SizeForParsing);
+                Xml_Pointer=Xml+Xml_Size-Xml_SizeForParsing;
+
+                //Check if we need to stop
+                if (!StatsFromExternalData_FileName_IsCompressed || strm.avail_out || inflate_Result == Z_STREAM_END)
+                    break;
+            }
+
+            //Coherency checks
+            if (Xml_Pointer>=Xml+Xml_MaxSize+Xml_HeaderSize)
+                break;
+        }
+
+        //Inform the parser that parsing is finished
+        Video->StatsFromExternalData_Finish();
+        Audio->StatsFromExternalData_Finish();
+
+        //Cleanup
+        if (StatsFromExternalData_FileName_IsCompressed)
+            inflateEnd(&strm);
+        delete[] Compressed;
+        delete[] Xml;
     }
     Glue=new FFmpeg_Glue(FileName_string.c_str(), ActiveAllTracks, &Stats, Stats.empty());
     if (FileName_string.empty())

--- a/Source/GUI/FileInformation.cpp
+++ b/Source/GUI/FileInformation.cpp
@@ -295,7 +295,9 @@ void FileInformation::Parse ()
     if (!isRunning() && ActiveParsing_Count<Max)
     {
         ActiveParsing_Count++;
-        start();
+
+        if(Glue)
+            start();
     }
 }
 

--- a/Source/GUI/FileInformation.cpp
+++ b/Source/GUI/FileInformation.cpp
@@ -554,6 +554,9 @@ bool FileInformation::PlayBackFilters_Available ()
 
 qreal FileInformation::averageFrameRate() const
 {
+    if(!Glue)
+        return 0;
+
     auto splitted = QString::fromStdString(Glue->AvgVideoFrameRate_Get()).split("/");
     if(splitted.length() == 1)
         return splitted[0].toDouble();
@@ -563,6 +566,9 @@ qreal FileInformation::averageFrameRate() const
 
 int FileInformation::BitsPerRawSample() const
 {
+    if(!Glue)
+        return 0;
+
     return Glue->BitsPerRawSample_Get();
 }
 


### PR DESCRIPTION
With the .gz stats file provided at https://github.com/bavc/qctools/issues/218#issuecomment-265199463, there is an huge memory allocation request (500 MB) and the XML parsing consumes up to 4 GB.
The stats file is for 1.5 hour of content, we can anticipate that someone would test a 3-hour file one day, so 8 GB only for QCTools with the current algorithm.
With the build at https://github.com/bavc/qctools/issues/218#issuecomment-265596923, I have sometimes a "Out of memory! Please try 64bit build." message despite the fact I run the 64-bit version, or a crash, depending of how loaded (RAM usage) is my machine (if ~2 GB free when I check the task manager, I have the message, but usually I have a crash because I have 5-6 GB free when I check the task manager, before I load the stat file). the machine has 16 GB of RAM but with Firefox, Thunderbird, Visual Studio and so on open so consuming some RAM.

This patch permits to reduce such problems, as it splits the stats file in chunks (note that as the XML library does not accept chunks, the XML is manually split in smaller valid XML documents; another possibility would be to have a XML parser that accept chunks).
As a result, only ~100 MB are needed during the XML parsing (could be reduced but with a bit more CPU used due to some calculations between chunks, looks like it is a good compromise), with a peek at 400 MB (then, after the XML parsing, 300 MB is used by the data stored in RAM for graphs).
As it is using chunks, it is expected that no more RAM is used with bigger stats files (except for storing data for graphs), so for a 3-hour file it should have a peak at 700 MB instead of 8 GB.
Bonus: it permits also to support hypothetical 4GB+ uncompressed .gz (the current code does not support it, as it reads a 32-bit value for the size of the buffer to allocate), which is "only" 8x less than the stats file we received.