### PR TITLE
adds missing documentation for some astats filters

### DIFF
--- a/Source/Resource/Help/Filter Descriptions/Filter Descriptions.html
+++ b/Source/Resource/Help/Filter Descriptions/Filter Descriptions.html
@@ -71,6 +71,15 @@
             <li>
                 <a href="#aphasemeter">Audio Phase Meter</a>
             </li>
+            <li>
+                <a href="#dcoffset">DC Offset</a>
+            </li>
+            <li>
+                <a href="#auddiffs">Audio Diffs</a>
+            </li>
+            <li>
+                <a href="#rms">RMS</a>
+            </li>
         </ol>
         <h2 style="color:blue">
             <a id="MinMaxAvgLowHigh" name="MinMaxAvgLowHigh">1. YUV Values/ MIN, AVG, MAX, LOW, HIGH</a>
@@ -573,10 +582,28 @@
             R 128 refers to a European Broadcasting Union (EBU) <a href="https://tech.ebu.ch/docs/r/r128.pdf">specification document</a> governing several loudness parameters, including momentary, integrated, and short-term loudness. QCTools specifically examines momentary loudness, or sudden changes in volume over brief intervals of time (up to 400ms). This can be helpful in identifying areas where volume may exceed upper loudness tolerance levels as perceived by an audience.
         </p>
         <h2 style="color:blue">
-            <a id="aphasemeter" name="aphasemeter">13. Audio Phase Meter</a>
+            <a id="aphasemeter" name="aphasemeter">17. Audio Phase Meter</a>
         </h2>
         <p>
             Provides a metric to represent the mean phase of each audio frames. Value is in range [-1, 1]. The -1 means left and right channels are completely out of phase and 1 means channels are in phase. See <a href="https://ffmpeg.org/ffmpeg-filters.html#aphasemeter">https://ffmpeg.org/ffmpeg-filters.html#aphasemeter</a> for more information.
+        </p>
+        <h2 style="color:blue">
+            <a id="dcoffset" name="dcoffset">18. DC Offset</a>
+        </h2>
+        <p>
+            For selected audio tracks this graph plots the DC offset (mean amplitude displacement from zero), minimal sample level, and maximum sample level. Note that this value is plotted per audio frame and not per audio sample.
+        </p>
+        <h2 style="color:blue">
+            <a id="auddiffs" name="auddiffs">19. Audio Diffs</a>
+        </h2>
+        <p>
+            For selected audio tracks this graph plots the minimal difference between two consecutive samples, maximal difference between two consecutive samples. and the mean difference between two consecutive samples (the average of each difference between two consecutive samples) A sharp spike in the maximum difference between consecuritve samples may be indictative of an interstitial error. Note that this value is plotted per audio frame and not per audio sample.
+        </p>
+        <h2 style="color:blue">
+            <a id="rms" name="rms">20. RMS</a>
+        </h2>
+        <p>
+            For selected audio tracks this graph plots the Standard peak and RMS level measured in dBFS and the Peak and trough values for RMS level measured over a short window.  Note that this value is plotted per audio frame and not per audio sample.        
         </p>
         <br/>
     </body>


### PR DESCRIPTION
Values taken from here: https://github.com/bavc/qctools/blob/2da00f1b9b1c8b168dc6332b85f8ce8691f2c698/Source/Core/AudioCore.cpp

Fixed numbering for aphase too, it was listed as .13.

-K