### PR TITLE
fix crash on tumbnail click if audio-only file loaded

### DIFF
--- a/Source/GUI/BigDisplay.cpp
+++ b/Source/GUI/BigDisplay.cpp
@@ -2362,7 +2362,7 @@ void BigDisplay::updateSelection(int Pos, ImageLabel* image, options& opts)
     }
     else
     {
-        image->setSelectionArea(0, 0, 0, 0);
+        image->clearSelectionArea();
     }
 }
 

--- a/Source/GUI/imagelabel.cpp
+++ b/Source/GUI/imagelabel.cpp
@@ -281,6 +281,16 @@ void ImageLabel::setSelectionArea(double x, double y, double w, double h)
     selectionArea->setGeometry(geometry);
 }
 
+void ImageLabel::clearSelectionArea()
+{
+    selectionPos.setX(0); selectionPos.setY(0); selectionSize.setWidth(0); selectionSize.setHeight(0);
+
+    QSignalBlocker blocker(selectionArea);
+
+    selectionArea->setMaxSize(0, 0);
+    selectionArea->setGeometry(QRect(0, 0, 0, 0));
+}
+
 void ImageLabel::showDebugOverlay(bool enable)
 {
     debugOverlay = enable;

--- a/Source/GUI/imagelabel.h
+++ b/Source/GUI/imagelabel.h
@@ -39,6 +39,8 @@ public Q_SLOTS:
     void setMaxSelectionSize(QSizeF size);
 
     void setSelectionArea(double x, double y, double w, double h);
+    void clearSelectionArea();
+
     void showDebugOverlay(bool enable);
 
 Q_SIGNALS:


### PR DESCRIPTION
should also resolve https://github.com/bavc/qctools/issues/255

note: Now I can open audio-only files but charts doesn't show any data. Is it something with my environment or everybody observe the same?