### PR TITLE
onStatsFileGenerationProgress slot uses 64-bit ints

### DIFF
--- a/Source/Cli/cli.cpp
+++ b/Source/Cli/cli.cpp
@@ -305,12 +305,12 @@ int Cli::exec(QCoreApplication &a)
 
         progress = unique_ptr<ProgressBar>(new ProgressBar(0, 100, 50, "%"));
 
-        QObject::connect(info.get(), SIGNAL(statsFileGenerationProgress(int, int)), this, SLOT(onStatsFileGenerationProgress(int, int)));
+        QObject::connect(info.get(), SIGNAL(statsFileGenerationProgress(quint64, quint64)), this, SLOT(onStatsFileGenerationProgress(quint64, quint64)));
         QObject::connect(info.get(), SIGNAL(statsFileGenerated(SharedFile, const QString&)), &a, SLOT(quit()));
         info->startExport(output);
         a.exec();
 
-        QObject::disconnect(info.get(), SIGNAL(statsFileGenerationProgress(int, int)), this, SLOT(onStatsFileGenerationProgress(int, int)));
+        QObject::disconnect(info.get(), SIGNAL(statsFileGenerationProgress(quint64, quint64)), this, SLOT(onStatsFileGenerationProgress(quint64, quint64)));
 
         std::cout << std::endl << "generating QCTools report... done" << std::endl;
     }
@@ -377,7 +377,7 @@ void Cli::updateParsingProgress()
     progress->setValue(value);
 }
 
-void Cli::onStatsFileGenerationProgress(int written, int total)
+void Cli::onStatsFileGenerationProgress(quint64 written, quint64 total)
 {
     statsFileBytesWritten = written;
     statsFileBytesTotal = total;

--- a/Source/Cli/cli.h
+++ b/Source/Cli/cli.h
@@ -78,7 +78,7 @@ public:
 
 public slots:
     void updateParsingProgress();
-    void onStatsFileGenerationProgress(int written, int total);
+    void onStatsFileGenerationProgress(quint64 written, quint64 total);
     void onSignalServerUploadProgressChanged(qint64 written, qint64 total);
 
 private:
@@ -89,8 +89,8 @@ private:
     QTimer progressTimer;
     int indexOfStreamWithKnownFrameCount;
 
-    int statsFileBytesWritten;
-    int statsFileBytesTotal;
+    quint64 statsFileBytesWritten;
+    quint64 statsFileBytesTotal;
 
     qint64 statsFileBytesUploaded;
     qint64 statsFileBytesToUpload;

--- a/Source/Core/FileInformation.h
+++ b/Source/Core/FileInformation.h
@@ -146,7 +146,7 @@ public Q_SLOTS:
 Q_SIGNALS:
     void positionChanged();
     void statsFileGenerated(SharedFile statsFile, const QString& name);
-    void statsFileGenerationProgress(int bytesWritten, int totalBytes);
+    void statsFileGenerationProgress(quint64 bytesWritten, quint64 totalBytes);
 
     void statsFileLoaded(SharedFile statsFile);
     void parsingCompleted(bool success);


### PR DESCRIPTION
Signed-off-by: Jérôme Martinez <jerome@mediaarea.net>

