### PR TITLE
requests images be built from (lowercase) docs folder

### DIFF
--- a/Project/QtCreator/qctools-gui/qctools-gui.pro
+++ b/Project/QtCreator/qctools-gui/qctools-gui.pro
@@ -84,7 +84,7 @@ FORMS += \
 RESOURCES += \
     $$SOURCES_PATH/Resource/Resources.qrc
 
-help_images_dir="$$SOURCES_PATH/../Docs/media"
+help_images_dir="$$SOURCES_PATH/../docs/media"
 help_images.files = $$files($$help_images_dir/*, true)
 help_images.prefix = "/Help"
 help_images.alias = "./"


### PR DESCRIPTION
This patch allows appropriate linking between images in /docs folder and built QCTools help pages.

Not sure why this wasn't broken for previously-loaded images, but both new and old images now seem to render appropriately upon build.

This images-loaded problem is affecting active PRs #328 and #329.