### PR TITLE
Font temporary file name must be escaped.

### DIFF
--- a/Source/GUI/BigDisplay.cpp
+++ b/Source/GUI/BigDisplay.cpp
@@ -2120,7 +2120,9 @@ string BigDisplay::FiltersList_currentOptionChanged(size_t Pos, size_t Picture_C
 
         if(fontFile.exists())
         {
-            str.replace(QString("${fontfile}"), fontFile.fileName());
+            QString fontFileName(fontFile.fileName());
+            fontFileName = fontFileName.replace(":", "\\\\:"); // ":" is a reserved character, it must be escaped
+            str.replace(QString("${fontfile}"), fontFileName);
         }
     }
 


### PR DESCRIPTION
e.g. "C:\" in the file name was messing up the filter string so the filter was inactive.