### PR TITLE
handle splitting fields after vrep

### DIFF
--- a/Source/GUI/BigDisplay.cpp
+++ b/Source/GUI/BigDisplay.cpp
@@ -741,7 +741,7 @@ const filter Filters[]=
         },
         {
             "signalstats=out=vrep:c=${2}",
-            "il=l=d:c=d,signalstats=out=vrep:c=${2}",
+            "signalstats=out=vrep:c=${2},il=l=d:c=d",
         },
     },
     {


### PR DESCRIPTION
fix to https://github.com/bavc/qctools/issues/400