### PR TITLE
adds 8bit if/else for limiter #440, fix of the fix

### DIFF
--- a/Source/GUI/BigDisplay.cpp
+++ b/Source/GUI/BigDisplay.cpp
@@ -1658,10 +1658,11 @@ void BigDisplay::FiltersList_currentIndexChanged(size_t Pos, size_t FilterPos, Q
                                     QString MaxTemp(Filters[FilterPos].Args[OptionPos].Name);
                                     if(strcmp(Filters[FilterPos].Name, "Limiter") == 0)
                                     {
-                                      if(FileInfoData->Glue->BitsPerRawSample_Get() == 0){
-                                        Max = 8;
-                                      } else
-                                        Max = pow(2, FileInfoData->Glue->BitsPerRawSample_Get()) - 1;
+                                        int BitsPerRawSample = FileInfoData->Glue->BitsPerRawSample_Get();
+                                        if (BitsPerRawSample == 0) {
+                                            BitsPerRawSample = 8; //Workaround when BitsPerRawSample is unknown, we hope it is 8-bit.
+                                        }
+                                        Max = pow(2, BitsPerRawSample) - 1;
                                     } else
                                     if (MaxTemp == "Line")
                                     {


### PR DESCRIPTION
Fix of https://github.com/bavc/qctools/pull/441 (actually Max is a power of the BitsPerRawSample, not directly BitsPerRawSample)