### PR TITLE
resizes and streamlines control panel

### DIFF
--- a/Source/GUI/Control.cpp
+++ b/Source/GUI/Control.cpp
@@ -66,53 +66,48 @@ Control::Control(QWidget *parent, FileInformation* FileInformationData_, bool Is
     Layout->setMargin(0);
     Layout->setContentsMargins(0,0,0,0);
 
+    Info_Time=new QLabel(this);
+    Info_Time->setFont(Font);
+    Info_Time->setAlignment(Qt::AlignCenter);
+    Layout->addWidget(Info_Time, 0, 0, 1, 1);
+
     M9=new QToolButton(this);
     M9->setText("<|");
     M9->setFont(Font);
     M9->setIcon(QIcon(":/icon/backward.png"));
-    M9->setIconSize(QSize(32, 32));
+    M9->setIconSize(QSize(23, 23));
     connect(M9, SIGNAL(clicked(bool)), this, SLOT(on_M9_clicked(bool)));
-    Layout->addWidget(M9, 0, 0, 1, 1);
+    Layout->addWidget(M9, 0, 1, 1, 1);
 
     M2=new QToolButton(this);
     M2->setText("-2x");
     M2->setFont(Font);
     connect(M2, SIGNAL(clicked(bool)), this, SLOT(on_M2_clicked(bool)));
-    Layout->addWidget(M2, 0, 1, 1, 1);
+    Layout->addWidget(M2, 0, 2, 1, 1);
 
     M1=new QToolButton(this);
     M1->setText("-1x");
     M1->setFont(Font);
     connect(M1, SIGNAL(clicked(bool)), this, SLOT(on_M1_clicked(bool)));
-    Layout->addWidget(M1, 0, 2, 1, 1);
+    Layout->addWidget(M1, 0, 3, 1, 1);
 
     M0=new QToolButton(this);
-    M0->setText("-0.5x");
+    M0->setText("-.5x");
     M0->setFont(Font);
     connect(M0, SIGNAL(clicked(bool)), this, SLOT(on_M0_clicked(bool)));
-    Layout->addWidget(M0, 0, 3, 1, 1);
+    Layout->addWidget(M0, 0, 4, 1, 1);
 
     Minus=new QToolButton(this);
     connect(Minus, SIGNAL(clicked(bool)), this, SLOT(on_Minus_clicked(bool)));
-    Minus->setText("Previous");
+    Minus->setText("Prev");
     Minus->setFont(Font);
-    Layout->addWidget(Minus, 0, 4, 1, 1);
-
-    Info_Time=new QLabel(this);
-    Info_Time->setFont(Font);
-    //QPalette Palette(Info_Time->palette());
-    //Palette.setColor(QPalette::Window, Qt::darkGray);
-    //Info_Time->setFont(Font);
-    //Info_Time->setPalette(Palette);
-    //Info_Time->setAutoFillBackground(true);
-    Info_Time->setAlignment(Qt::AlignCenter);
-    Layout->addWidget(Info_Time, 0, 5, 1, 1);
+    Layout->addWidget(Minus, 0, 5, 1, 1);
 
     PlayPause=new QToolButton(this);
     PlayPause->setText(">");
     PlayPause->setFont(Font);
     PlayPause->setIcon(QIcon(":/icon/play.png"));
-    PlayPause->setIconSize(QSize(48, 48));
+    PlayPause->setIconSize(QSize(23, 23));
     connect(PlayPause, SIGNAL(clicked(bool)), this, SLOT(on_PlayPause_clicked(bool)));
 
     Layout->addWidget(PlayPause, 0, 6, 1, 1);
@@ -121,47 +116,42 @@ Control::Control(QWidget *parent, FileInformation* FileInformationData_, bool Is
     Pause->setVisible(false);
     connect(Pause, SIGNAL(clicked(bool)), this, SLOT(on_Pause_clicked(bool)));
 
-    Info_Frames=new QLabel(this);
-    Info_Frames->setFont(Font);
-    //Palette=Info_Frames->palette();
-    //Palette.setColor(QPalette::Window, Qt::darkGray);
-    //Info_Frames->setFont(Font);
-    //Info_Frames->setPalette(Palette);
-    //Info_Frames->setAutoFillBackground(true);
-    Info_Frames->setAlignment(Qt::AlignCenter);
-    Layout->addWidget(Info_Frames, 0, 7, 1, 1);
-
     Plus=new QToolButton(this);
     connect(Plus, SIGNAL(clicked(bool)), this, SLOT(on_Plus_clicked(bool)));
-    Plus->setText("   Next   ");
+    Plus->setText("Next");
     Plus->setFont(Font);
-    Layout->addWidget(Plus, 0, 8, 1, 1);
+    Layout->addWidget(Plus, 0, 7, 1, 1);
 
     P0=new QToolButton(this);
-    P0->setText("+0.5x");
+    P0->setText("+.5x");
     P0->setFont(Font);
     connect(P0, SIGNAL(clicked(bool)), this, SLOT(on_P0_clicked(bool)));
-    Layout->addWidget(P0, 0, 9, 1, 1);
+    Layout->addWidget(P0, 0, 8, 1, 1);
 
     P1=new QToolButton(this);
     P1->setText("+1x");
     P1->setFont(Font);
     connect(P1, SIGNAL(clicked(bool)), this, SLOT(on_P1_clicked(bool)));
-    Layout->addWidget(P1, 0, 10, 1, 1);
+    Layout->addWidget(P1, 0, 9, 1, 1);
 
     P2=new QToolButton(this);
     P2->setText("+2x");
     P2->setFont(Font);
     connect(P2, SIGNAL(clicked(bool)), this, SLOT(on_P2_clicked(bool)));
-    Layout->addWidget(P2, 0, 11, 1, 1);
+    Layout->addWidget(P2, 0, 10, 1, 1);
 
     P9=new QToolButton(this);
     P9->setText("|>");
     P9->setFont(Font);
     P9->setIcon(QIcon(":/icon/forward.png"));
-    P9->setIconSize(QSize(32, 32));
+    P9->setIconSize(QSize(23, 23));
     connect(P9, SIGNAL(clicked(bool)), this, SLOT(on_P9_clicked(bool)));
-    Layout->addWidget(P9, 0, 12, 1, 1);
+    Layout->addWidget(P9, 0, 11, 1, 1);
+
+    Info_Frames=new QLabel(this);
+    Info_Frames->setFont(Font);
+    Info_Frames->setAlignment(Qt::AlignCenter);
+    Layout->addWidget(Info_Frames, 0, 12, 1, 1);
 
     setLayout(Layout);
 


### PR DESCRIPTION
This moves and resizes the main panel's controls to be consistently sized. It moves the timecode and frames to the outer regions and puts all of the playback controls together, in the center, like below:

![screen shot 2017-11-27 at 15 04 44](https://user-images.githubusercontent.com/3260492/33287297-44d08374-d386-11e7-865c-4fec06eeaa49.png)
