### PR TITLE
slightly less space between preview thumbnails

### DIFF
--- a/Source/GUI/TinyDisplay.cpp
+++ b/Source/GUI/TinyDisplay.cpp
@@ -66,7 +66,7 @@ void TinyDisplay::resizeEvent(QResizeEvent *e)
 void TinyDisplay::thumbsLayoutResized()
 {
     const int width = QWidget::width();
-    const int THUMB_WANTED_WIDTH = 120;
+    const int THUMB_WANTED_WIDTH = 108;
 
     if (lastWidth != width) {
         int total_thumbs = width / THUMB_WANTED_WIDTH;


### PR DESCRIPTION
This is a small change, from the current spacing between thumbnails to slightly less space.

# Before:

![screen shot 2017-11-27 at 17 51 57](https://user-images.githubusercontent.com/3260492/33293733-cb384860-d39b-11e7-996e-6e1c1cfd3eb5.png)


# Proposed:

![screen shot 2017-11-27 at 17 51 11](https://user-images.githubusercontent.com/3260492/33293736-cd718ce0-d39b-11e7-87e1-da5fb93a1ab2.png)

# Why?

Why bother with such a small change? I find that giving a space of 120 makes the space a bit uncomfortable -- it's not big enough to be spaced as far apart as the width of the thumbnails, but also not close enough to feel right, either. I want to change this to 108, which is the equivalent of 1.5 spaces between each of the thumbnails. Because of the window being overall responsive, this number is always going to fluctuate as it creates more and less thumbnails (shrinking the window, you'll see it goes down to 3 on either side with 120 or 108, and expanding it brings back more), which creates trouble when trying to align them more closely to each other. On average, though, the spacing feels more "appropriate" in the sense of it being a gutter space, rather than wide enough to consider whether there should be an additional something to fill that space.

If this doesn't feel right, I'm inclined to going in the opposite direction and making the spacing set to "double" a thumbnail's distance, so there's 1/2 on either side:

![screen shot 2017-11-27 at 18 00 42](https://user-images.githubusercontent.com/3260492/33294018-d0415e2c-d39c-11e7-8134-c52109a5dfb3.png)
