### PR TITLE
styles selectedFilters and allows squishing

### DIFF
--- a/Source/GUI/mainwindow_Ui.cpp
+++ b/Source/GUI/mainwindow_Ui.cpp
@@ -136,11 +136,27 @@ void MainWindow::Ui_Init()
             QPushButton* CheckBox=new QPushButton(PerStreamType[type].PerGroup[group].Name);
 
             QFontMetrics metrics(CheckBox->font());
-            CheckBox->setMinimumWidth(metrics.width(CheckBox->text()) + 10);
+            CheckBox->setMinimumWidth(metrics.width(CheckBox->text()));
             CheckBox->setCheckable(true);
-
+            CheckBox->setFlat(true);
             CheckBox->setProperty("type", (quint64) type); // unfortunately QVariant doesn't support size_t
             CheckBox->setProperty("group", (quint64) group);
+            CheckBox->setStyleSheet("\
+                QPushButton {\
+                    color: black;\
+                    padding-top: 8px;\
+                    padding-bottom: 8px;\
+                    border: solid;\
+                    border-color: lightgrey;\
+                    border-width: 0 0 0 1px;\
+                }\
+                QPushButton:checked{\
+                    background-color: grey;\
+                }\
+                QPushButton:hover{\
+                    background-color: lightgrey;\
+                }  \
+                ");
 
             CheckBox->setToolTip(PerStreamType[type].PerGroup[group].Description);
 
@@ -161,13 +177,30 @@ void MainWindow::Ui_Init()
             CheckBoxes[type].push_back(CheckBox);
         }
 
-    m_commentsCheckbox=new QPushButton("comments");
+    m_commentsCheckbox=new QPushButton("Comments");
     QFontMetrics metrics(m_commentsCheckbox->font());
-    m_commentsCheckbox->setMinimumWidth(metrics.width(m_commentsCheckbox->text()) + 10);
+    m_commentsCheckbox->setMinimumWidth(metrics.width(m_commentsCheckbox->text()));
 
     m_commentsCheckbox->setProperty("type", (quint64) Type_Max);
     m_commentsCheckbox->setProperty("group", (quint64) 0);
     m_commentsCheckbox->setToolTip("comments");
+    m_commentsCheckbox->setFlat(true);
+    m_commentsCheckbox->setStyleSheet("\
+        QPushButton {\
+            color: black;\
+            padding-top: 8px;\
+            padding-bottom: 8px;\
+            border: solid;\
+            border-color: lightgrey;\
+            border-width: 0 1px 0 0;\
+        }\
+        QPushButton:checked{\
+            background-color: grey;\
+        }\
+        QPushButton:hover{\
+            background-color: lightgrey;\
+        }  \
+        ");
     m_commentsCheckbox->setCheckable(true);
     m_commentsCheckbox->setChecked(true);
     m_commentsCheckbox->setVisible(false);
@@ -461,7 +494,7 @@ void MainWindow::Export_PDF()
 
     /*
     QwtPlotRenderer PlotRenderer;
-    PlotRenderer.renderDocument(const_cast<QwtPlot*>( PlotsArea->plot(TempType, Group_Y) ), 
+    PlotRenderer.renderDocument(const_cast<QwtPlot*>( PlotsArea->plot(TempType, Group_Y) ),
         SaveFileName, "PDF", QSizeF(210, 297), 150);
     QDesktopServices::openUrl(QUrl("file:///"+SaveFileName, QUrl::TolerantMode));
     */


### PR DESCRIPTION
The Filter toggle boxes at the top of QCTools were looking strange and having trouble squishing down. It would look like this with normal screen load-size:

![screen shot 2017-11-27 at 20 46 37](https://user-images.githubusercontent.com/3260492/33299334-18b98410-d3b9-11e7-84d0-e997074b2062.png)

I added the setFlat parameter and styled the filters so they would all look like this:

![screen shot 2017-11-27 at 21 21 23](https://user-images.githubusercontent.com/3260492/33299355-2befb478-d3b9-11e7-9cb9-88d109ab0b0a.png)

(You can't see it, but I added a color-change when hovering too).

And the window, when necessary, can get smaller (not pretty, but wasn't pretty before):

![screen shot 2017-11-27 at 21 21 30](https://user-images.githubusercontent.com/3260492/33299373-45af803c-d3b9-11e7-8149-16eea94fb17d.png)

I think it might be good to break these filters into two rows instead of struggling to fit them all into one, following a logic pattern of "when reaching X amount of filters, break line"