### PR TITLE
renames (in GUI) eliminate to hide

### DIFF
--- a/Source/GUI/barchartconditioninput.ui
+++ b/Source/GUI/barchartconditioninput.ui
@@ -65,7 +65,7 @@
    <item>
     <widget class="QCheckBox" name="eliminateSpikes_checkBox">
      <property name="text">
-      <string>Eliminate spikes</string>
+      <string>Hide spikes</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
This was a request in the bar chart feature PR. I didn't rename the variable but just what the GUI says, which I think is OK.