### PR TITLE
always re-generate statistics if 'force overwrite' selected

### DIFF
--- a/Source/Cli/cli.cpp
+++ b/Source/Cli/cli.cpp
@@ -276,7 +276,7 @@ int Cli::exec(QCoreApplication &a)
             indexOfStreamWithKnownTotal = framesCountForAllStreams[i];
     }
 
-    if(!info->hasStats())
+    if(!info->hasStats() || forceOutput)
     {
         // parse
 


### PR DESCRIPTION
should fix https://github.com/bavc/qctools/issues/473