### PR TITLE
A few more fixes

### DIFF
--- a/Source/Core/FFmpeg_Glue.cpp
+++ b/Source/Core/FFmpeg_Glue.cpp
@@ -1134,7 +1134,9 @@ void FFmpeg_Glue::Seek(size_t FramePos)
             {
                 Seek_TimeStamp=FramePos;
                 Seek_TimeStamp*=InputData->Stream->duration;
-                Seek_TimeStamp/=InputData->FrameCount;  // TODO: seek based on time stamp
+
+                if(InputData->FrameCount != 0)
+                    Seek_TimeStamp/=InputData->FrameCount;  // TODO: seek based on time stamp
             }
     
             // Seek

--- a/Source/Core/FFmpeg_Glue.cpp
+++ b/Source/Core/FFmpeg_Glue.cpp
@@ -2639,6 +2639,12 @@ QByteArray FFmpeg_Glue::getAttachment(const QString &fileName, QString& attachme
     return attachment;
 }
 
+int FFmpeg_Glue::pixelFormatBPP(int pixelFormat)
+{
+    const AVPixFmtDescriptor *desc = av_pix_fmt_desc_get((AVPixelFormat) pixelFormat);
+    return av_get_bits_per_pixel(desc);
+}
+
 FFmpeg_Glue::Image::Image()
 {
 

--- a/Source/Core/FFmpeg_Glue.h
+++ b/Source/Core/FFmpeg_Glue.h
@@ -152,6 +152,7 @@ public:
     static string               FFmpeg_LibsVersion();
 
     static QByteArray           getAttachment(const QString& fileName, QString& attachmentFileName);
+    static int                  pixelFormatBPP(int pixelFormat);
 
     // Actions
     void                        AddInput_Video(size_t FrameCount, int time_base_num, int time_base_den, int Width, int Height, int BitDepth, bool Compression, int TimecodeBCD=-1);

--- a/Source/Core/FileInformation.cpp
+++ b/Source/Core/FileInformation.cpp
@@ -879,10 +879,7 @@ bool FileInformation::isValid() const
 
 int FileInformation::BitsPerRawSample() const
 {
-    if(!Glue)
-        return 0;
-
-    return Glue->BitsPerRawSample_Get();
+    return ReferenceStat() ? FFmpeg_Glue::pixelFormatBPP(*ReferenceStat()->pix_fmt) : Glue ? Glue->BitsPerRawSample_Get() : 0;
 }
 
 FileInformation::SignalServerCheckUploadedStatus FileInformation::signalServerCheckUploadedStatus() const

--- a/Source/Core/VideoStats.cpp
+++ b/Source/Core/VideoStats.cpp
@@ -470,7 +470,7 @@ int VideoStats::getWidth() const
 
 void VideoStats::setWidth(int width)
 {
-    width = width;
+    this->width = width;
 }
 
 int VideoStats::getHeight() const
@@ -480,7 +480,7 @@ int VideoStats::getHeight() const
 
 void VideoStats::setHeight(int height)
 {
-    height = height;
+    this->height = height;
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
- use first frame's pixel bpp instead of bitsPerRawSample if stats is available
- fix serializing width/height
- dont' crash on zero divison (even if such weird situation happen)