### PR TITLE
remove support for dotXml sidecars

### DIFF
--- a/Source/Core/FileInformation.cpp
+++ b/Source/Core/FileInformation.cpp
@@ -296,7 +296,6 @@ FileInformation::FileInformation (SignalServer* signalServer, const QString &Fil
     static const QString dotQctoolsDotXmlDotGz = ".qctools.xml.gz";
     static const QString dotQctoolsDotXml = ".qctools.xml";
     static const QString dotXmlDotGz = ".xml.gz";
-    static const QString dotXml = ".xml";
     static const QString dotQctoolsDotMkv = ".qctools.mkv";
 
     QByteArray attachment;
@@ -318,11 +317,6 @@ FileInformation::FileInformation (SignalServer* signalServer, const QString &Fil
         StatsFromExternalData_FileName=FileName;
         FileName.resize(FileName.length() - dotXmlDotGz.length());
         StatsFromExternalData_FileName_IsCompressed=true;
-    }
-    else if (FileName.endsWith(dotXml))
-    {
-        StatsFromExternalData_FileName=FileName;
-        FileName.resize(FileName.length() - dotXml.length());
     }
     else if (FileName.endsWith(dotQctoolsDotMkv))
     {
@@ -349,10 +343,6 @@ FileInformation::FileInformation (SignalServer* signalServer, const QString &Fil
         {
             StatsFromExternalData_FileName=FileName + dotXmlDotGz;
             StatsFromExternalData_FileName_IsCompressed=true;
-        }
-        else if (QFile::exists(FileName + dotXml))
-        {
-            StatsFromExternalData_FileName=FileName + dotXml;
         }
         else if (QFile::exists(FileName + dotQctoolsDotMkv))
         {


### PR DESCRIPTION
fixes https://github.com/bavc/qctools/issues/452
This will break functions if anyone is storing sidecar qctools report
in  “${filename}.xml” format, but ${filename}.qctools.xml.gz and
${filename}.qctools.xml and ${filename}.xml.gz and
${filename}.qctools.mkv are still supported.