### PR TITLE
qctools-cli.pro: fix build on case-sensitive file systems

### DIFF
--- a/Project/QtCreator/qctools-cli/qctools-cli.pro
+++ b/Project/QtCreator/qctools-cli/qctools-cli.pro
@@ -71,7 +71,7 @@ macx:LIBS += -liconv \
              -framework CoreFoundation \
              -framework Foundation \
              -framework AppKit \
-             -framework AudioToolBox \
+             -framework AudioToolbox \
              -framework QuartzCore \
              -framework CoreGraphics \
              -framework CoreAudio \


### PR DESCRIPTION
The framework is AudioToolbox not AudioToolBox.

Fixes https://github.com/bavc/qctools/issues/539.