### PR TITLE
sets blank default version

### DIFF
--- a/Source/Core/Core.cpp
+++ b/Source/Core/Core.cpp
@@ -11,7 +11,7 @@
 #include <string.h>
 
 //---------------------------------------------------------------------------
-const char* Version="0.8.0";
+const char* Version="0.0.0";
 
 //---------------------------------------------------------------------------
 const struct stream_info PerStreamType    [Type_Max] =

--- a/Source/Install/QCTools.nsi
+++ b/Source/Install/QCTools.nsi
@@ -5,7 +5,7 @@ RequestExecutionLevel admin
 ; Some defines
 !define PRODUCT_NAME "QCTools"
 !define PRODUCT_PUBLISHER "MediaArea.net"
-!define PRODUCT_VERSION "0.8.0"
+!define PRODUCT_VERSION "0.0.0"
 !define PRODUCT_VERSION4 "${PRODUCT_VERSION}.0"
 !define PRODUCT_WEB_SITE "http://www.bavc.org/qctools"
 !define COMPANY_REGISTRY "Software\MediaArea.net"


### PR DESCRIPTION
For/resolves #558. @JeromeMartinez helpfully pushes current version when building. This sets local dev builds to 0.0.0.

Not a thorough sweep but iterative improvement.