### PR TITLE
Ensure additional stats map is initialized before incrementing xCurrent

### DIFF
--- a/Source/Core/AudioStats.cpp
+++ b/Source/Core/AudioStats.cpp
@@ -179,6 +179,11 @@ void AudioStats::StatsFromExternalData(const char* Data, size_t Size)
                             Tag=Tag->NextSiblingElement();
                         }
 
+                        if(!statsMapInitialized) {
+                            initializeAdditionalStats();
+                            statsMapInitialized=true;
+                        }
+
                         if (x_Max[0]<=x[0][x_Current])
                         {
                             x_Max[0]=x[0][x_Current];
@@ -186,6 +191,7 @@ void AudioStats::StatsFromExternalData(const char* Data, size_t Size)
                             x_Max[2]=x[2][x_Current];
                             x_Max[3]=x[3][x_Current];
                         }
+
                         x_Current++;
                         if (x_Current_Max<=x_Current)
                             x_Current_Max=x_Current;

--- a/Source/Core/VideoStats.cpp
+++ b/Source/Core/VideoStats.cpp
@@ -259,6 +259,11 @@ void VideoStats::StatsFromExternalData (const char* Data, size_t Size)
                             Tag=Tag->NextSiblingElement();
                         }
 
+                        if(!statsMapInitialized) {
+                            initializeAdditionalStats();
+                            statsMapInitialized=true;
+                        }
+
                         if (x_Max[0]<=x[0][x_Current])
                         {
                             x_Max[0]=x[0][x_Current];
@@ -266,6 +271,7 @@ void VideoStats::StatsFromExternalData (const char* Data, size_t Size)
                             x_Max[2]=x[2][x_Current];
                             x_Max[3]=x[3][x_Current];
                         }
+
                         x_Current++;
                         if (x_Current_Max<=x_Current)
                             x_Current_Max=x_Current;


### PR DESCRIPTION
Solves crashes on macOS from #556, and invalid data in others platforms