### PR TITLE
Other Github Actions improvements

### DIFF
--- a/.github/workflows/qctools.yml
+++ b/.github/workflows/qctools.yml
@@ -199,7 +199,7 @@ jobs:
     - name: Install FFmpeg
       run: |
         cd ..
-        $FFMPEG_VERSION = "ffmpeg-4.2.1-win64"
+        $FFMPEG_VERSION = "ffmpeg-latest-win64"
         $LINK_DEV = "https://ffmpeg.zeranoe.com/builds/win64/dev"
         $LINK_SHARED = "https://ffmpeg.zeranoe.com/builds/win64/shared"
         curl -LO "$LINK_DEV/$FFMPEG_VERSION-dev.zip"
@@ -291,7 +291,7 @@ jobs:
     - name: Install FFmpeg
       run: |
         cd ..
-        $FFMPEG_VERSION = "ffmpeg-4.2.1-win64"
+        $FFMPEG_VERSION = "ffmpeg-latest-win64"
         $LINK_DEV = "https://ffmpeg.zeranoe.com/builds/win64/dev"
         $LINK_SHARED = "https://ffmpeg.zeranoe.com/builds/win64/shared"
         curl -LO "$LINK_DEV/$FFMPEG_VERSION-dev.zip"

--- a/.github/workflows/qctools.yml
+++ b/.github/workflows/qctools.yml
@@ -8,20 +8,11 @@ jobs:
 
     strategy:
       matrix:
-        compiler: ['gcc-7', 'gcc-8', 'gcc-9', 'clang-6', 'clang-9']
+        compiler: ['gcc-9', 'clang-9']
         include:
-          - compiler: gcc-7
-            packages: gcc@7
-            env: { 'CC': 'gcc-7', 'CXX': 'g++-7' }
-          - compiler: gcc-8
-            packages: gcc@8
-            env: { 'CC': 'gcc-8', 'CXX': 'g++-8' }
           - compiler: gcc-9
             packages: gcc@9
             env: { 'CC': 'gcc-9', 'CXX': 'g++-9' }
-          - compiler: clang-6
-            packages: llvm@6
-            env: { 'CC': 'clang-6.0', 'CXX': 'clang++-6.0' }
           - compiler: clang-9
             packages: llvm@9
             env: { 'CC': 'clang-9', 'CXX': 'clang++-9' }
@@ -53,20 +44,11 @@ jobs:
 
     strategy:
       matrix:
-        compiler: ['gcc-7', 'gcc-8', 'gcc-9', 'clang-6', 'clang-9']
+        compiler: ['gcc-9', 'clang-9']
         include:
-          - compiler: gcc-7
-            packages: gcc@7
-            env: { 'CC': 'gcc-7', 'CXX': 'g++-7' }
-          - compiler: gcc-8
-            packages: gcc@8
-            env: { 'CC': 'gcc-8', 'CXX': 'g++-8' }
           - compiler: gcc-9
             packages: gcc@9
             env: { 'CC': 'gcc-9', 'CXX': 'g++-9' }
-          - compiler: clang-6
-            packages: llvm@6
-            env: { 'CC': 'clang-6.0', 'CXX': 'clang++-6.0' }
           - compiler: clang-9
             packages: llvm@9
             env: { 'CC': 'clang-9', 'CXX': 'clang++-9' }

--- a/.github/workflows/qctools.yml
+++ b/.github/workflows/qctools.yml
@@ -105,14 +105,11 @@ jobs:
 
     strategy:
       matrix:
-        compiler: ['gcc-7', 'gcc-8', 'gcc-9', 'clang-6', 'clang-9']
+        compiler: ['gcc-7', 'gcc-9', 'clang-6', 'clang-9']
         include:
           - compiler: gcc-7
             packages: gcc-7 g++-7
             env: { 'CC': 'gcc-7', 'CXX': 'g++-7' }
-          - compiler: gcc-8
-            packages: gcc-8 g++-8
-            env: { 'CC': 'gcc-8', 'CXX': 'g++-8' }
           - compiler: gcc-9
             packages: gcc-9 g++-9
             env: { 'CC': 'gcc-9', 'CXX': 'g++-9' }

--- a/.github/workflows/qctools.yml
+++ b/.github/workflows/qctools.yml
@@ -199,6 +199,20 @@ jobs:
         echo "::add-path::C:/msys64/usr/bin"
         echo "::add-path::C:/msys64/mingw64/bin"
 
+    - name: Install FFmpeg
+      run: |
+        cd ..
+        $FFMPEG_VERSION = "ffmpeg-4.2.1-win64"
+        $LINK_DEV = "https://ffmpeg.zeranoe.com/builds/win64/dev"
+        $LINK_SHARED = "https://ffmpeg.zeranoe.com/builds/win64/shared"
+        curl -LO "$LINK_DEV/$FFMPEG_VERSION-dev.zip"
+        curl -LO "$LINK_SHARED/$FFMPEG_VERSION-shared.zip"
+        7z x "$FFMPEG_VERSION-dev.zip"
+        7z x "$FFMPEG_VERSION-shared.zip"
+        Rename-Item -Path ".\$FFMPEG_VERSION-dev" -NewName ".\ffmpeg"
+        Rename-Item -Path ".\$FFMPEG_VERSION-shared" -NewName ".\ffmpeg_shared"
+        Move-Item -Path .\ffmpeg_shared\bin\* -Destination .\ffmpeg\lib
+
     - name: Initialize msys2
       run: |
         bash -lc "exit"
@@ -209,9 +223,7 @@ jobs:
 
     - name: Install build packages
       run: |
-        pacman -S --needed --ask=20 --noconfirm make `
-                                                mingw-w64-x86_64-gcc `
-                                                mingw-w64-x86_64-ffmpeg
+        pacman -S --needed --ask=20 --noconfirm make mingw-w64-x86_64-gcc
 
     - name: Download and configure qwt
       run: |

--- a/Project/QtCreator/qctools-cli/qctools-cli.pro
+++ b/Project/QtCreator/qctools-cli/qctools-cli.pro
@@ -59,15 +59,6 @@ win32-g++* {
     LIBS += -lbcrypt -lwsock32 -lws2_32
 }
 
-!win32 {
-    LIBS      += -lbz2
-}
-
-unix {
-    LIBS       += -ldl
-    !macx:LIBS += -lrt
-}
-
 macx:LIBS += -liconv \
              -framework CoreFoundation \
              -framework Foundation \

--- a/Project/QtCreator/qctools-gui/qctools-gui.pro
+++ b/Project/QtCreator/qctools-gui/qctools-gui.pro
@@ -213,15 +213,6 @@ win32-g++* {
     LIBS += -lbcrypt -lwsock32 -lws2_32
 }
 
-!win32 {
-    LIBS      += -lbz2
-}
-
-unix {
-    LIBS       += -ldl
-    !macx:LIBS += -lrt
-}
-
 macx:ICON = $$SOURCES_PATH/Resource/Logo.icns
 macx:LIBS += -liconv \
              -framework CoreFoundation \


### PR DESCRIPTION
- Since Github Actions allows to run only five `macos` jobs concurrently, it would be better to remove old compilers in order to reduce the workload. In addition, those compilers are already being tested by the `Ubuntu` jobs

- Use official FFmpeg builds for Windows jobs

- Do not link to unused libraries

Thanks in advance for your review! :)

