### PR TITLE
update min macos to 10.8

### DIFF
--- a/HowToCompile.txt
+++ b/HowToCompile.txt
@@ -69,7 +69,7 @@ cd ffmpeg
 make
 Copy *.lib in Project\MSVC2013\GUI\Lib
 Mac:
-./configure --enable-gpl --enable-version3 --enable-shared --disable-swscale-alpha --disable-doc --disable-ffplay --disable-ffprobe --disable-ffserver --disable-debug --enable-libopenjpeg --disable-decoder=jpeg2000 --yasmexe=../yasm/yasm --extra-cflags="-I../openjpeg/usr/include" --extra-ldflags="-L../openjpeg/usr/lib -mmacosx-version-min=10.5"
+./configure --enable-gpl --enable-version3 --enable-shared --disable-swscale-alpha --disable-doc --disable-ffplay --disable-ffprobe --disable-ffserver --disable-debug --enable-libopenjpeg --disable-decoder=jpeg2000 --yasmexe=../yasm/yasm --extra-cflags="-I../openjpeg/usr/include" --extra-ldflags="-L../openjpeg/usr/lib -mmacosx-version-min=10.8"
 make
 Linux (static build):
 ./configure --enable-gpl --enable-version3 --disable-shared --enable-static --disable-swscale-alpha --disable-doc --disable-ffplay --disable-ffprobe --disable-ffserver --disable-debug --enable-libopenjpeg --disable-decoder=jpeg2000 --extra-cflags="-I../openjpeg/usr/include" --extra-ldflags="-L../openjpeg/usr/lib"

--- a/Project/BuildAllFromSource/init_ffmpeg.sh
+++ b/Project/BuildAllFromSource/init_ffmpeg.sh
@@ -17,7 +17,7 @@ fi
     FFMPEG_CONFIGURE_OPTS=(--enable-gpl --enable-version3 --disable-securetransport --disable-videotoolbox --enable-shared --disable-static --disable-doc --disable-ffplay --disable-ffprobe --disable-debug --disable-lzma --disable-iconv --enable-pic)
 
     if sw_vers >/dev/null 2>&1 ; then
-        FFMPEG_CONFIGURE_OPTS+=(--extra-cflags="-mmacosx-version-min=10.7" --extra-ldflags="-mmacosx-version-min=10.7")
+        FFMPEG_CONFIGURE_OPTS+=(--extra-cflags="-mmacosx-version-min=10.8" --extra-ldflags="-mmacosx-version-min=10.8")
     fi
 
     chmod u+x configure


### PR DESCRIPTION
Otherwise we get this error

```
2 warnings generated.
OBJCC	libavdevice/avfoundation.o
libavdevice/avfoundation.m:207:14: error: 'objectForKeyedSubscript:' is only available on macOS 10.8 or newer
      [-Werror,-Wunguarded-availability]
            [change[NSKeyValueChangeNewKey] integerValue];
             ^~~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/System/Library/Frameworks/Foundation.framework/Headers/NSDictionary.h:46:1: note: 
      'objectForKeyedSubscript:' has been marked as being introduced in macOS 10.8 here, but the deployment target is macOS 10.7.0
- (nullable ObjectType)objectForKeyedSubscript:(KeyType)key API_AVAILABLE(macos(10.8), ios(6.0), watchos(2.0), tvos(9.0));
^
libavdevice/avfoundation.m:207:14: note: enclose 'objectForKeyedSubscript:' in an @available check to silence this warning
            [change[NSKeyValueChangeNewKey] integerValue];
             ^~~~~~
1 error generated.
make: *** [libavdevice/avfoundation.o] Error 1
```