### PR TITLE
Fix thumbnails generation broken 

### DIFF
--- a/Source/Core/FFmpeg_Glue.cpp
+++ b/Source/Core/FFmpeg_Glue.cpp
@@ -333,6 +333,7 @@ void FFmpeg_Glue::outputdata::ApplyScale(const AVFramePtr& sourceFrame)
 
     ScaledFrame->width=Width;
     ScaledFrame->height=Height;
+    ScaledFrame->format=sourceFrame->format;
 
     av_image_alloc(ScaledFrame->data, ScaledFrame->linesize, Width, Height, OutputMethod==Output_QImage?AV_PIX_FMT_RGB24:AV_PIX_FMT_YUVJ420P, 1);
     if (sws_scale(ScaleContext, sourceFrame->data, sourceFrame->linesize, 0, sourceFrame->height, ScaledFrame->data, ScaledFrame->linesize)<0)

--- a/Source/Core/FFmpeg_Glue.cpp
+++ b/Source/Core/FFmpeg_Glue.cpp
@@ -378,10 +378,17 @@ void FFmpeg_Glue::outputdata::AddThumbnail()
         return;
     }
 
-    int got_packet=0;
-    int result = avcodec_encode_video2(JpegOutput_CodecContext, jpegOutPacket.get(), OutputFrame.get(), &got_packet);
+    int result = avcodec_send_frame(JpegOutput_CodecContext, OutputFrame.get());
+    if (result < 0)
+    {
+        char buffer[256];
+        qDebug() << av_make_error_string(buffer, sizeof buffer, result);
+        Thumbnails.push_back(std::move(jpegOutPacket));
+        return;
+    }
 
-    if (result < 0 || !got_packet)
+    result = avcodec_receive_packet(JpegOutput_CodecContext, jpegOutPacket.get());
+    if (result != 0)
     {
         char buffer[256];
         qDebug() << av_make_error_string(buffer, sizeof buffer, result);


### PR DESCRIPTION
Thumbnails generation is broken with newest FFmpeg ([93016f5d1d, 2020-06-18](https://github.com/FFmpeg/FFmpeg/commit/93016f5d1d280f9cb7856883af287fa66affc04c)).

& As the work about switching to the new API was done during debugging, there is a commit about that so we don't need to do it later.