### PR TITLE
Fix stack overflow when skimming in graphs

### DIFF
--- a/Source/GUI/player.cpp
+++ b/Source/GUI/player.cpp
@@ -757,6 +757,9 @@ void Player::applyFilter()
 
 void Player::handleFileInformationPositionChanges()
 {
+    if (m_ignorePositionChanges)
+        return;
+
     if(m_player->isPaused() && m_seekOnFileInformationPositionChange) {
 
         auto ms = frameToMs(m_fileInformation->Frames_Pos_Get());


### PR DESCRIPTION
When skimming in graphs, I have often a stack overflow due to recursive function calls.
This patch breaks the recessivity.