### PR TITLE
Refactor Export menu

### DIFF
--- a/Source/GUI/mainwindow.h
+++ b/Source/GUI/mainwindow.h
@@ -168,15 +168,17 @@ private Q_SLOTS:
 
     void on_Toolbar_visibilityChanged(bool visible);
 
-    void on_actionImport_XmlGz_Prompt_triggered();
+    void on_actionExport_Mkv_Prompt_triggered();
+
+    void on_actionExport_Mkv_Sidecar_triggered();
+
+    void on_actionExport_Mkv_SidecarAll_triggered();
 
     void on_actionExport_XmlGz_Prompt_triggered();
 
     void on_actionExport_XmlGz_Sidecar_triggered();
 
     void on_actionExport_XmlGz_SidecarAll_triggered();
-
-    void on_actionExport_XmlGz_Custom_triggered();
 
     void on_actionPrint_triggered();
 
@@ -233,8 +235,6 @@ private Q_SLOTS:
     void on_actionClear_Recent_History_triggered();
 
     void on_actionReveal_file_location_triggered();
-
-    void on_actionExport_Mkv_Prompt_triggered();
 
     void on_actionGrab_frame_triggered();
 

--- a/Source/GUI/mainwindow.ui
+++ b/Source/GUI/mainwindow.ui
@@ -180,12 +180,6 @@
     <addaction name="separator"/>
     <addaction name="actionAbout"/>
    </widget>
-   <widget class="QMenu" name="menuImport">
-    <property name="title">
-     <string>Import</string>
-    </property>
-    <addaction name="actionImport_XmlGz_Prompt"/>
-   </widget>
    <widget class="QMenu" name="menuExport">
     <property name="title">
      <string>Export</string>
@@ -193,11 +187,21 @@
     <property name="toolTipsVisible">
      <bool>true</bool>
     </property>
-    <addaction name="actionExport_XmlGz_Prompt"/>
+    <widget class="QMenu" name="menuLegacy_outputs">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="title">
+      <string>Legacy outputs</string>
+     </property>
+     <addaction name="actionExport_XmlGz_Prompt"/>
+     <addaction name="actionExport_XmlGz_Sidecar"/>
+     <addaction name="actionExport_XmlGz_SidecarAll"/>
+    </widget>
     <addaction name="actionExport_Mkv_Prompt"/>
-    <addaction name="actionExport_XmlGz_Sidecar"/>
-    <addaction name="actionExport_XmlGz_SidecarAll"/>
-    <addaction name="actionExport_XmlGz_Custom"/>
+    <addaction name="actionExport_Mkv_Sidecar"/>
+    <addaction name="actionExport_Mkv_SidecarAll"/>
+    <addaction name="menuLegacy_outputs"/>
     <addaction name="separator"/>
     <addaction name="actionSignalServer_status"/>
     <addaction name="actionUploadToSignalServer"/>
@@ -213,7 +217,6 @@
    </widget>
    <addaction name="menuFile"/>
    <addaction name="menuView"/>
-   <addaction name="menuImport"/>
    <addaction name="menuOptions"/>
    <addaction name="menuExport"/>
    <addaction name="menuHelp"/>
@@ -414,20 +417,10 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>To .qctools.xml.gz...</string>
+    <string>To QCTools Report (.qctools.xml.gz)...</string>
    </property>
    <property name="menuRole">
     <enum>QAction::NoRole</enum>
-   </property>
-  </action>
-  <action name="actionImport_XmlGz_Prompt">
-   <property name="text">
-    <string>From .qctools.xml.gz...</string>
-   </property>
-  </action>
-  <action name="actionPreferences">
-   <property name="text">
-    <string>Preferences</string>
    </property>
   </action>
   <action name="actionExport_XmlGz_Sidecar">
@@ -435,23 +428,47 @@
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>To sidecar .qctools.xml.gz</string>
+    <string>To sidecar QCTools Report (.qctools.xml.gz)</string>
+   </property>
+  </action>
+  <action name="actionExport_XmlGz_SidecarAll">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>All open files to sidecar QCTools Report (.qctools.xml.gz)</string>
+   </property>
+  </action>
+  <action name="actionExport_Mkv_Prompt">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>To QCTools Report (.qctools.mkv)...</string>
+   </property>
+  </action>
+  <action name="actionExport_Mkv_Sidecar">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>To sidecar QCTools Report (.qctools.mkv)</string>
    </property>
    <property name="shortcut">
     <string>Ctrl+S</string>
    </property>
   </action>
-  <action name="actionExport_XmlGz_Custom">
+  <action name="actionExport_Mkv_SidecarAll">
    <property name="enabled">
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>To prefered directory</string>
+    <string>All open files to sidecar QCTools Report (.qctools.mkv)</string>
    </property>
   </action>
-  <action name="actionExport_XmlGz_SidecarAll">
+  <action name="actionPreferences">
    <property name="text">
-    <string>To sidecar .qctools.xml.gz (All files)</string>
+    <string>Preferences</string>
    </property>
   </action>
   <action name="actionZoomOne">
@@ -552,11 +569,6 @@
   <action name="actionReveal_file_location">
    <property name="text">
     <string>Reveal file location</string>
-   </property>
-  </action>
-  <action name="actionExport_Mkv_Prompt">
-   <property name="text">
-    <string>To .qctools.mkv..</string>
    </property>
   </action>
   <action name="actionPlay_Pause">

--- a/Source/GUI/mainwindow_More.cpp
+++ b/Source/GUI/mainwindow_More.cpp
@@ -101,6 +101,7 @@ void MainWindow::closeFile()
         else
             setFilesCurrentPos(getFilesCurrentPos()<Files.size()?getFilesCurrentPos():getFilesCurrentPos()-1);
 
+        updateExportActions();
         TimeOut();
     }
 }
@@ -124,6 +125,7 @@ void MainWindow::closeAllFiles()
     createDragDrop();
     ui->actionFilesList->setChecked(false);
     ui->actionGraphsLayout->setChecked(false);
+    updateExportAllAction();
 }
 
 //---------------------------------------------------------------------------

--- a/Source/GUI/mainwindow_Ui.cpp
+++ b/Source/GUI/mainwindow_Ui.cpp
@@ -351,10 +351,6 @@ void MainWindow::Ui_Init()
     ui->actionWindowOut->setVisible(false);
     ui->actionPrint->setVisible(false);
 
-    // Not implemented action
-    if (ui->actionExport_XmlGz_Custom)
-        ui->actionExport_XmlGz_Custom->setVisible(false);
-
     QStringList recentFiles = preferences->recentFiles();
 
     int recentFilesIndex = recentFiles.length();
@@ -406,9 +402,6 @@ void MainWindow::configureZoom()
         }
 
         ui->actionGoTo->setEnabled(!Files.empty());
-        ui->actionExport_XmlGz_Prompt->setEnabled(!Files.empty());
-        ui->actionExport_XmlGz_Sidecar->setEnabled(!Files.empty());
-        ui->actionExport_XmlGz_Custom->setEnabled(!Files.empty());
         //ui->actionPrint->setEnabled(!Files.empty());
         return;
     }
@@ -417,9 +410,6 @@ void MainWindow::configureZoom()
     ui->actionZoomOut->setEnabled(true);
     ui->actionZoomIn->setEnabled( isPlotZoomable() );
     ui->actionGoTo->setEnabled(true);
-    ui->actionExport_XmlGz_Prompt->setEnabled(true);
-    ui->actionExport_XmlGz_Sidecar->setEnabled(true);
-    ui->actionExport_XmlGz_Custom->setEnabled(true);
     //ui->actionPrint->setEnabled(true);
 }
 


### PR DESCRIPTION
Handle more cases (all of them?), disable all by default, reorder, make `.qctools.mkv` the main option in the export menu, put `.qctools.xml.gz` in a submenu.

![image](https://user-images.githubusercontent.com/1641638/96643624-1fea4b00-1328-11eb-866e-e80c010af646.png)

Fix https://github.com/bavc/qctools/issues/655.

Note: toolbar still has the `.qctools.xml.gz` option, it will be in another PR (mkv icon design to add).