### PR TITLE
QCvault

### DIFF
--- a/Source/Cli/cli.cpp
+++ b/Source/Cli/cli.cpp
@@ -2,6 +2,7 @@
 #include "version.h"
 #include "Core/FFmpegVideoEncoder.h"
 #include "Core/FFmpeg_Glue.h"
+#include <QDir>
 
 Cli::Cli() : indexOfStreamWithKnownFrameCount(0), statsFileBytesWritten(0), statsFileBytesTotal(0), statsFileBytesUploaded(0), statsFileBytesToUpload(0)
 {
@@ -12,7 +13,6 @@ int Cli::exec(QCoreApplication &a)
 {
     std::string appName = "qcli";
     std::string copyright = "Copyright (C): 2013-2020, BAVC.\nCopyright (C): 2018-2020, RiceCapades LLC & MediaArea.net SARL.";
-
     Preferences prefs;
 
     QString input;
@@ -23,6 +23,8 @@ int Cli::exec(QCoreApplication &a)
     bool showShortHelp = false;
     bool showVersion = false;
     bool createMkv = true;
+    QString useQCvault;
+    bool ignoreQCvault = false;
     bool configIsSet = false;
     bool configHasIssues = false;
 
@@ -63,6 +65,76 @@ int Cli::exec(QCoreApplication &a)
         } else if(a.arguments().at(i) == "-v")
         {
             showVersion = true;
+        }
+        else if (a.arguments().at(i) == "-qcvault")
+        {
+            ++i;
+            if (i >= a.arguments().length())
+            {
+                std::cout << "Missing argument after last option." << std::endl;
+                configHasIssues = true;
+                continue;
+            }
+
+            useQCvault = a.arguments().at(i);
+            if (useQCvault == "default")
+            {
+                useQCvault = prefs.defaultQCvaultPathString();
+                if (useQCvault.isEmpty())
+                {
+                    std::cout << "QCvault location can not be found." << std::endl;
+                    configHasIssues = true;
+                    continue;
+                }
+            }
+        } else if (a.arguments().at(i) == "-clear-qcvault")
+        {
+            configIsSet = true;
+
+            prefs.setQCvaultPathString(QString());
+            useQCvault = prefs.QCvaultPathString();
+            if (!useQCvault.isEmpty())
+            {
+                std::cout << "QCvault location can not be saved." << std::endl;
+                configHasIssues = true;
+                continue;
+            }
+            std::cout << "QCvault cleared." << std::endl;
+        } else if (a.arguments().at(i) == "-set-qcvault")
+        {
+            ++i;
+            if (i >= a.arguments().length() || a.arguments().at(i).isEmpty())
+            {
+                std::cout << "Missing argument after last option." << std::endl;
+                configHasIssues = true;
+                continue;
+            }
+            configIsSet = true;
+
+            prefs.setQCvaultPathString(a.arguments().at(i));
+            useQCvault = prefs.QCvaultPathString();
+            if (useQCvault.isEmpty())
+            {
+                std::cout << "QCvault location can not be saved." << std::endl;
+                configHasIssues = true;
+                continue;
+            }
+            std::cout << "QCvault set to " << useQCvault.toStdString() << std::endl;
+        } else if (a.arguments().at(i) == "-show-qcvault")
+        {
+            configIsSet = true;
+            bool HasError;
+            auto QCvaultPathString = prefs.QCvaultPathString(&HasError);
+            if (HasError)
+            {
+                std::cout << "Default QCvault location not available, use -qcvault instead, analyzing stopped." << std::endl;
+                configHasIssues = true;
+                continue;
+            }
+            if (QCvaultPathString.isEmpty())
+                std::cout << "QCvault path is not set." << std::endl;
+            else
+                std::cout << "QCvault path is " << QCvaultPathString.toStdString() << '.' << std::endl;
         } else if (a.arguments().at(i) == "-s")
         {
             createMkv = false;
@@ -178,6 +250,21 @@ int Cli::exec(QCoreApplication &a)
         }
     }
 
+    // QCvault
+    if (!ignoreQCvault && useQCvault.isEmpty())
+    {
+        bool HasError;
+        useQCvault = prefs.QCvaultPathString(&HasError);
+        if (HasError)
+        {
+            std::cout << "App local data location not available, use -qcvault instead, analyzing stopped.. " << std::endl;
+            configHasIssues = true;
+        }
+    }
+
+    if (configHasIssues)
+        return InvalidInput;
+
     if(!showLongHelp)
     {
         if(a.arguments().length() == 1 || (checkUploadFileName.isEmpty() && input.isEmpty()))
@@ -195,6 +282,9 @@ int Cli::exec(QCoreApplication &a)
 
     if(showLongHelp || showShortHelp)
     {
+        if (configIsSet)
+            return Success;
+
         if(showShortHelp)
         {
             std::cout <<
@@ -219,6 +309,16 @@ int Cli::exec(QCoreApplication &a)
                 << "-a" << std::endl
                 << "    All (stats + thumbnails + panels)." << std::endl
                 << "    Is default." << std::endl
+                << "-qcvault <QCvault path>" << std::endl
+                << "    Use the indicated path as the QCvault location." << std::endl
+                << "    Use \"-qcvault default\" for using the standard QCvault location." << std::endl
+                << "-set-qcvault <QCvault path>" << std::endl
+                << "    Register the indicated path as the QCvault location." << std::endl
+                << "    Use \"-set-qcvault default\" for using the standard QCvault location." << std::endl
+                << "-show-qcvault" << std::endl
+                << "    Show the registered QCvault location." << std::endl
+                << "-clear-qcvault" << std::endl
+                << "    Clear the QCvault location. Default directory becomes the input directory." << std::endl
                 << "-show-panels" << std::endl
                 << "    Show the available panels." << std::endl
                 << "    First column is an index to be used with -activate-panel or -deactivate-panel." << std::endl
@@ -323,6 +423,30 @@ int Cli::exec(QCoreApplication &a)
 
     if(!input.endsWith(".qctools.xml.gz") && !input.endsWith(".qctools.mkv")) // skip output if input is already .qctools.xml.gz
     {
+        if (!useQCvault.isEmpty())
+        {
+            if (!output.isEmpty())
+            {
+                std::cout << "-qcvault and -o can not be used at same time, analyzing stopped." << std::endl;
+                return InvalidInput;
+            }
+
+            auto fileNameQCvault = prefs.createQCvaultFileNameString(input, useQCvault);
+            if (fileNameQCvault.isEmpty())
+            {
+                std::cout << "Problem while creating output file name, analyzing stopped." << std::endl;
+                return InvalidInput;
+            }
+
+            output = fileNameQCvault + (createMkv ? ".qctools.mkv" : ".qctools.xml.gz");
+            auto outPath = QFileInfo(output).dir();
+            if (!outPath.mkpath("."))
+            {
+                std::cout << "Can not create output directory, analyzing stopped." << std::endl;
+                return InvalidInput;
+            }
+        }
+
         if(output.isEmpty())
             output = input + (createMkv ? ".qctools.mkv" : ".qctools.xml.gz");
     }
@@ -405,7 +529,7 @@ int Cli::exec(QCoreApplication &a)
 
     std::cout << std::endl;
 
-    info = std::unique_ptr<FileInformation>(new FileInformation(signalServer.get(), input, filters, prefs.activeAllTracks(), prefs.getActivePanels()));
+    info = std::unique_ptr<FileInformation>(new FileInformation(signalServer.get(), input, filters, prefs.activeAllTracks(), prefs.getActivePanels(), prefs.createQCvaultFileNameString(input)));
     info->setAutoCheckFileUploaded(false);
     info->setAutoUpload(false);
 
@@ -413,7 +537,7 @@ int Cli::exec(QCoreApplication &a)
 
     if(!info->isValid())
     {
-        std::cout << "invalid input, analyzing aborted.. " << std::endl;
+        std::cout << "invalid input, analyzing stopped.. " << std::endl;
         return InvalidInput;
     }
 

--- a/Source/Core/FileInformation.h
+++ b/Source/Core/FileInformation.h
@@ -49,6 +49,7 @@ public:
                                 FileInformation             (SignalServer* signalServer, const QString &fileName,
                                                              activefilters ActiveFilters, activealltracks ActiveAllTracks,
                                                              QMap<QString, std::tuple<QString, QString, QString, QString, int>> activePanels,
+                                                             const QString &cacheFileNamePrefix,
                                                              int FrameCount=0);
                                 ~FileInformation            ();
 

--- a/Source/Core/Preferences.h
+++ b/Source/Core/Preferences.h
@@ -57,6 +57,11 @@ public:
     bool isSignalServerAutoUploadEnabled() const;
     void setSignalServerAutoUploadEnabled(bool enabled);
 
+    QString QCvaultPathString(bool* IssueWithDefaultQCvaultPath = nullptr) const;
+    void setQCvaultPathString(const QString & urlString);
+    QString defaultQCvaultPathString() const;
+    QString createQCvaultFileNameString(const QString & input, const QString & cacheDir = QString()) const;
+
     QString signalServerUrlString() const;
     void setSignalServerUrlString(const QString & urlString);
 

--- a/Source/GUI/mainwindow.cpp
+++ b/Source/GUI/mainwindow.cpp
@@ -319,6 +319,46 @@ void MainWindow::on_actionExport_Mkv_SidecarAll_triggered()
 }
 
 //---------------------------------------------------------------------------
+void MainWindow::on_actionExport_Mkv_QCvault_triggered()
+{
+    if (getFilesCurrentPos() >= Files.size() || !Files[getFilesCurrentPos()])
+        return;
+
+    QString FileName = preferences->createQCvaultFileNameString(Files[getFilesCurrentPos()]->fileName()) + ".qctools.mkv";
+    auto outPath = QFileInfo(FileName).dir();
+    if (!outPath.mkpath("."))
+    {
+        statusBar()->showMessage("Can not create output directory");
+        return;
+    }
+
+    Files[getFilesCurrentPos()]->Export_QCTools_Mkv(FileName, Prefs->ActiveFilters);
+    statusBar()->showMessage("Exported to " + FileName);
+}
+
+//---------------------------------------------------------------------------
+void MainWindow::on_actionExport_Mkv_QCvaultAll_triggered()
+{
+    for (size_t Pos = 0; Pos < Files.size(); ++Pos)
+    {
+        auto file = Files[Pos];
+        bool parsed = file->parsed();
+        if (!parsed)
+            continue; // Does not export if not fully parsed
+
+        QString FileName = preferences->createQCvaultFileNameString(Files[Pos]->fileName()) + ".qctools.mkv";
+        auto outPath = QFileInfo(FileName).dir();
+        if (!outPath.mkpath("."))
+        {
+            statusBar()->showMessage("Can not create output directory");
+            return;
+        }
+
+        file->Export_QCTools_Mkv(FileName, Prefs->ActiveFilters);
+    }
+}
+
+//---------------------------------------------------------------------------
 void MainWindow::on_actionPrint_triggered()
 {
     Export_PDF();
@@ -339,6 +379,8 @@ void MainWindow::on_actionFilesList_triggered()
         ui->actionExport_Mkv_Prompt->setVisible(false);
     if (ui->actionExport_Mkv_Sidecar)
         ui->actionExport_Mkv_Sidecar->setVisible(false);
+    if (ui->actionExport_Mkv_QCvault)
+        ui->actionExport_Mkv_QCvault->setVisible(false);
     if (ui->actionPrint)
         ui->actionPrint->setVisible(false);
     if (ui->actionZoomIn)
@@ -637,6 +679,11 @@ void MainWindow::updateSignalServerSettings()
     uploadAction()->setVisible(Prefs->isSignalServerEnabled());
     uploadAllAction()->setVisible(Prefs->isSignalServerEnabled());
     ui->actionSignalServer_status->setVisible(Prefs->isSignalServerEnabled());
+
+    // Update visibility of export to QCvault
+    bool QCvaultPathStringIsFilled = !Prefs->QCvaultPathString().isEmpty();
+    ui->actionExport_Mkv_QCvault->setVisible(QCvaultPathStringIsFilled);
+    ui->actionExport_Mkv_QCvaultAll->setVisible(QCvaultPathStringIsFilled);
 }
 
 template <typename T> QString convertEnumToQString(const char* typeName, int value)
@@ -762,6 +809,7 @@ void MainWindow::updateExportActions()
     ui->actionExport_XmlGz_Sidecar->setEnabled(exportEnabled);
     ui->actionExport_Mkv_Prompt->setEnabled(exportEnabled);
     ui->actionExport_Mkv_Sidecar->setEnabled(exportEnabled);
+    ui->actionExport_Mkv_QCvault->setEnabled(exportEnabled);
 
     ui->menuLegacy_outputs->setEnabled(ui->actionExport_XmlGz_Prompt->isEnabled() || ui->actionExport_XmlGz_Sidecar->isEnabled() || ui->actionExport_XmlGz_SidecarAll->isEnabled());
 }
@@ -779,6 +827,7 @@ void MainWindow::updateExportAllAction()
 
     ui->actionExport_XmlGz_SidecarAll->setEnabled(allParsedOrHaveStats);
     ui->actionExport_Mkv_SidecarAll->setEnabled(allParsedOrHaveStats);
+    ui->actionExport_Mkv_QCvaultAll->setEnabled(allParsedOrHaveStats);
 
     ui->menuLegacy_outputs->setEnabled(ui->actionExport_XmlGz_Prompt->isEnabled() || ui->actionExport_XmlGz_Sidecar->isEnabled() || ui->actionExport_XmlGz_SidecarAll->isEnabled());
 }

--- a/Source/GUI/mainwindow.h
+++ b/Source/GUI/mainwindow.h
@@ -174,6 +174,10 @@ private Q_SLOTS:
 
     void on_actionExport_Mkv_SidecarAll_triggered();
 
+    void on_actionExport_Mkv_QCvault_triggered();
+
+    void on_actionExport_Mkv_QCvaultAll_triggered();
+
     void on_actionExport_XmlGz_Prompt_triggered();
 
     void on_actionExport_XmlGz_Sidecar_triggered();

--- a/Source/GUI/mainwindow.ui
+++ b/Source/GUI/mainwindow.ui
@@ -201,6 +201,8 @@
     <addaction name="actionExport_Mkv_Prompt"/>
     <addaction name="actionExport_Mkv_Sidecar"/>
     <addaction name="actionExport_Mkv_SidecarAll"/>
+    <addaction name="actionExport_Mkv_QCvault"/>
+    <addaction name="actionExport_Mkv_QCvaultAll"/>
     <addaction name="menuLegacy_outputs"/>
     <addaction name="separator"/>
     <addaction name="actionSignalServer_status"/>
@@ -458,12 +460,28 @@
     <string>Ctrl+S</string>
    </property>
   </action>
+  <action name="actionExport_Mkv_QCvault">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>To QCvault (.qctools.mkv)</string>
+   </property>
+  </action>
   <action name="actionExport_Mkv_SidecarAll">
    <property name="enabled">
     <bool>false</bool>
    </property>
    <property name="text">
     <string>All open files to sidecar QCTools Report (.qctools.mkv)</string>
+   </property>
+  </action>
+  <action name="actionExport_Mkv_QCvaultAll">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>All open files to QCvault directory (.qctools.mkv)</string>
    </property>
   </action>
   <action name="actionPreferences">

--- a/Source/GUI/mainwindow_More.cpp
+++ b/Source/GUI/mainwindow_More.cpp
@@ -101,7 +101,6 @@ void MainWindow::closeFile()
         else
             setFilesCurrentPos(getFilesCurrentPos()<Files.size()?getFilesCurrentPos():getFilesCurrentPos()-1);
 
-        updateExportActions();
         TimeOut();
     }
 }

--- a/Source/GUI/mainwindow_More.cpp
+++ b/Source/GUI/mainwindow_More.cpp
@@ -165,7 +165,7 @@ void MainWindow::processFile(const QString &FileName)
     statusBar()->showMessage("Scanning "+QFileInfo(FileName).fileName()+"...");
 
     // Launch analysis
-    FileInformation* file = new FileInformation(signalServer, FileName, Prefs->ActiveFilters, Prefs->ActiveAllTracks, preferences->getActivePanels());
+    FileInformation* file = new FileInformation(signalServer, FileName, Prefs->ActiveFilters, Prefs->ActiveAllTracks, preferences->getActivePanels(), preferences->createQCvaultFileNameString(FileName));
     connect(file, SIGNAL(positionChanged()), this, SLOT(Update()), Qt::DirectConnection); // direct connection is required here to get Update called from separate thread
     file->setIndex(Files.size());
     file->setExportFilters(Prefs->ActiveFilters);
@@ -493,7 +493,7 @@ void MainWindow::addFile(const QString &FileName)
         return;
 
     // Launch analysis
-    FileInformation* Temp=new FileInformation(signalServer, FileName, Prefs->ActiveFilters, Prefs->ActiveAllTracks, preferences->getActivePanels());
+    FileInformation* Temp=new FileInformation(signalServer, FileName, Prefs->ActiveFilters, Prefs->ActiveAllTracks, preferences->getActivePanels(), preferences->createQCvaultFileNameString(FileName));
     connect(Temp, SIGNAL(positionChanged()), this, SLOT(Update()), Qt::DirectConnection); // direct connection is required here to get Update called from separate thread
     connect(Temp, SIGNAL(parsingCompleted(bool)), this, SLOT(updateExportAllAction()));
 

--- a/Source/GUI/mainwindow_Ui.cpp
+++ b/Source/GUI/mainwindow_Ui.cpp
@@ -402,6 +402,8 @@ void MainWindow::configureZoom()
         }
 
         ui->actionGoTo->setEnabled(!Files.empty());
+        ui->actionExport_XmlGz_Prompt->setEnabled(!Files.empty());
+        ui->actionExport_XmlGz_Sidecar->setEnabled(!Files.empty());
         //ui->actionPrint->setEnabled(!Files.empty());
         return;
     }
@@ -410,6 +412,8 @@ void MainWindow::configureZoom()
     ui->actionZoomOut->setEnabled(true);
     ui->actionZoomIn->setEnabled( isPlotZoomable() );
     ui->actionGoTo->setEnabled(true);
+    ui->actionExport_XmlGz_Prompt->setEnabled(true);
+    ui->actionExport_XmlGz_Sidecar->setEnabled(true);
     //ui->actionPrint->setEnabled(true);
 }
 

--- a/Source/GUI/preferences.cpp
+++ b/Source/GUI/preferences.cpp
@@ -17,6 +17,8 @@
 #include <QNetworkRequest>
 #include <QNetworkReply>
 #include <QTimer>
+#include <QFileDialog>
+#include <QDesktopServices>
 //---------------------------------------------------------------------------
 
 //***************************************************************************
@@ -43,6 +45,16 @@ PreferencesDialog::PreferencesDialog(Preferences* preferences, SignalServerConne
 PreferencesDialog::~PreferencesDialog()
 {
     delete ui;
+}
+
+QString PreferencesDialog::QCvaultPathString() const
+{
+    return preferences->QCvaultPathString();
+}
+
+QString PreferencesDialog::defaultQCvaultPathString() const
+{
+    return preferences->defaultQCvaultPathString();
 }
 
 bool PreferencesDialog::isSignalServerEnabled() const
@@ -116,6 +128,19 @@ void PreferencesDialog::Load()
     ui->Tracks_Audio_First->setChecked(!ActiveAllTracks[Type_Audio]);
     ui->Tracks_Audio_All->setChecked(ActiveAllTracks[Type_Audio]);
 
+    if (QCvaultPathString().isEmpty())
+        ui->QCvaultPath_None->setChecked(true);
+    else if (QCvaultPathString()==defaultQCvaultPathString())
+    {
+        ui->QCvaultPath_lineEdit->setText(defaultQCvaultPathString());
+        ui->QCvaultPath_Default->setChecked(true);
+    }
+    else
+    {
+        ui->QCvaultPath_lineEdit->setText(QCvaultPathString());
+        ui->QCvaultPath_Custom->setChecked(true);
+    }
+
     ui->signalServerUrl_lineEdit->setText(signalServerUrlString());
     ui->signalServerLogin_lineEdit->setText(signalServerLogin());
     ui->signalServerPassword_lineEdit->setText(signalServerPassword());
@@ -135,6 +160,9 @@ void PreferencesDialog::Save()
     for (auto it = activePanelsNames.begin(); it != activePanelsNames.end(); ++it)
         A.insert(*it);
     preferences->setActivePanels(A);
+
+    preferences->setQCvaultPathString(ui->QCvaultPath_lineEdit->text());
+
     preferences->setSignalServerUrlString(ui->signalServerUrl_lineEdit->text());
     preferences->setSignalServerLogin(ui->signalServerLogin_lineEdit->text());
     preferences->setSignalServerPassword(ui->signalServerPassword_lineEdit->text());
@@ -259,4 +287,51 @@ void PreferencesDialog::on_signalServerUrl_lineEdit_editingFinished()
         ui->signalServerUrl_lineEdit->setText(url);
         ui->signalServerUrl_lineEdit->blockSignals(false);
     }
+}
+
+void PreferencesDialog::on_QCvaultPath_None_toggled(bool checked)
+{
+    if (checked)
+    {
+        ui->QCvaultPath_lineEdit->setText(QString());
+        ui->QCvaultPath_lineEdit->setEnabled(false);
+        ui->QCvaultPath_select->setEnabled(false);
+        ui->QCvaultPath_open->setEnabled(false);
+    }
+}
+
+void PreferencesDialog::on_QCvaultPath_Default_toggled(bool checked)
+{
+    if (checked)
+    {
+        ui->QCvaultPath_lineEdit->setText(defaultQCvaultPathString());
+        ui->QCvaultPath_lineEdit->setEnabled(false);
+        ui->QCvaultPath_select->setEnabled(false);
+        ui->QCvaultPath_open->setEnabled(true);
+    }
+}
+
+void PreferencesDialog::on_QCvaultPath_Custom_toggled(bool checked)
+{
+    if (checked)
+    {
+        //ui->QCvaultPath_lineEdit->setEnabled(true);
+        ui->QCvaultPath_select->setEnabled(true);
+        ui->QCvaultPath_open->setEnabled(true);
+    }
+}
+
+void PreferencesDialog::on_QCvaultPath_select_clicked(bool checked)
+{
+    QString Directory = QFileDialog::getExistingDirectory(this, "Select QCvault directory",
+                                                                ui->QCvaultPath_lineEdit->text(),
+                                                                QFileDialog::ShowDirsOnly
+                                                                | QFileDialog::DontResolveSymlinks);
+    if (!Directory.isEmpty())
+        ui->QCvaultPath_lineEdit->setText(Directory);
+}
+
+void PreferencesDialog::on_QCvaultPath_open_clicked(bool checked)
+{
+    QDesktopServices::openUrl(ui->QCvaultPath_lineEdit->text());
 }

--- a/Source/GUI/preferences.h
+++ b/Source/GUI/preferences.h
@@ -31,6 +31,9 @@ public:
     bool isSignalServerEnabled() const;
     bool isSignalServerAutoUploadEnabled() const;
 
+    QString QCvaultPathString() const;
+    QString defaultQCvaultPathString() const;
+
     QString signalServerUrlString() const;
     QString signalServerLogin() const;
     QString signalServerPassword() const;
@@ -52,6 +55,11 @@ private Q_SLOTS:
     void OnAccepted();
     void OnRejected();
     void on_signalServerUrl_lineEdit_editingFinished();
+    void on_QCvaultPath_None_toggled(bool checked);
+    void on_QCvaultPath_Default_toggled(bool checked);
+    void on_QCvaultPath_Custom_toggled(bool checked);
+    void on_QCvaultPath_select_clicked(bool checked = false);
+    void on_QCvaultPath_open_clicked(bool checked = false);
 };
 
 #endif // PREFERENCES_DIALOG_H

--- a/Source/GUI/preferences.ui
+++ b/Source/GUI/preferences.ui
@@ -240,6 +240,94 @@
        </item>
       </layout>
      </widget>
+     <widget class="QWidget" name="QCvault">
+      <attribute name="title">
+       <string>QCvault</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_10">
+       <item>
+        <layout class="QVBoxLayout" name="verticalLayout_15">
+         <item>
+          <widget class="QGroupBox" name="groupBox_6">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="title">
+            <string>QCvault path</string>
+           </property>
+           <layout class="QVBoxLayout" name="verticalLayout_16">
+            <item>
+             <layout class="QGridLayout" name="gridLayout_3">
+              <item row="0" column="0">
+               <widget class="QRadioButton" name="QCvaultPath_None">
+                <property name="text">
+                 <string>None (Same path as source)</string>
+                </property>
+                <property name="checked">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QRadioButton" name="QCvaultPath_Default">
+                <property name="text">
+                 <string>Default system QCvault path</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="0">
+               <widget class="QRadioButton" name="QCvaultPath_Custom">
+                <property name="text">
+                 <string>Custom</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="1">
+               <widget class="QPushButton" name="QCvaultPath_select">
+                <property name="text">
+                 <string>Choose...</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="2">
+               <widget class="QPushButton" name="QCvaultPath_open">
+                <property name="text">
+                 <string>Show QCvault path</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="0">
+               <widget class="QLineEdit" name="QCvaultPath_lineEdit">
+                <property name="readOnly">
+                 <bool>false</bool>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
      <widget class="QWidget" name="Signalserver">
       <attribute name="title">
        <string>Signalserver</string>


### PR DESCRIPTION
Options for a cache directory instead of default sidecar file.
Cache directory may also be accessed by 2 different computers having 2 different root paths for the content directory.
Cache directory may be set per qcli call (option at each call) or for all qcli calls (configure once then all other calls use it).

CLI:
```
-cd <cache directory path>
    Use the indicated path as the cache directory location.
    Use "-cd default" for using the standard cache directory location.
-set-cd <cache directory path>
    Register the indicated path as the cache directory location.
    Use "-set-cd default" for using the standard cache directory location.
-show-cd
    Show the registered cache directory location.
-clear-cd
    Clear the cache directory location. Default directory becomes the input directory.
```

GUI:
![image](https://user-images.githubusercontent.com/1641638/96748346-b3c02380-13c9-11eb-992e-1c202866dbea.png)
