### PR TITLE
reset pts in axcorrelate

### DIFF
--- a/Source/Core/panels.json
+++ b/Source/Core/panels.json
@@ -51,7 +51,7 @@
         "name" : "Audio Normalized Cross-correlation",
         "legend" : "Audio Normalized\nCross-correlation",
         "yaxis" : "Out of Phase Correlation:Uncorrelated:In Phase Correlation",
-        "filterchain" : "channelsplit,axcorrelate=algo=fast,showwaves=mode=point:colors=white:size=${PANEL_WIDTH}x${DEFAULT_HEIGHT}:scale=lin:draw=full:rate=${AUDIO_FRAME_RATE}/${PANEL_WIDTH},format=rgb24,geq=r=if(gt(p(X\\,Y)\\,128)\\,Y*256/${DEFAULT_HEIGHT}\\,0):g=if(gt(p(X\\,Y)\\,128)\\,256-(Y*256/${DEFAULT_HEIGHT})\\,0):b=0,setsar=1/1,format=rgb24",
+        "filterchain" : "aformat=channel_layouts=stereo,channelsplit,axcorrelate=algo=fast,showwaves=mode=point:colors=white:size=${PANEL_WIDTH}x${DEFAULT_HEIGHT}:scale=lin:draw=full:rate=${AUDIO_FRAME_RATE}/${PANEL_WIDTH},format=rgb24,geq=r=if(gt(p(X\\,Y)\\,128)\\,Y*256/${DEFAULT_HEIGHT}\\,0):g=if(gt(p(X\\,Y)\\,128)\\,256-(Y*256/${DEFAULT_HEIGHT})\\,0):b=0,setsar=1/1,format=rgb24,setpts=N/(${PANEL_WIDTH}/${AUDIO_FRAME_RATE})/TB",
         "panel_type" : "audio",
         "version" : "1.0"
     },


### PR DESCRIPTION
Currently the pts of the images of the axcorrelate/showwaves panel are somehow strangely off and toss increase the duration of the qctools mkv report to an extreme value. I tried using setpts here to force the images to increment every 16 seconds but this still doesn't work quite right, but does make it so that the panel track is shorter than the others rather than longer. Since the pts of panel images aren't used in the display, I'd suggest to merge this as it at least makes the issue less annoying though it doesn't resolve it.