### PR TITLE
Use native file dialogs for all platforms

### DIFF
--- a/Source/GUI/mainwindow.cpp
+++ b/Source/GUI/mainwindow.cpp
@@ -244,7 +244,7 @@ void MainWindow::on_actionExport_XmlGz_Prompt_triggered()
     if (getFilesCurrentPos()>=Files.size() || !Files[getFilesCurrentPos()])
         return;
 
-    QString FileName=QFileDialog::getSaveFileName(this, "Export to .qctools.xml.gz", Files[getFilesCurrentPos()]->fileName() + ".qctools.xml.gz", "Statistic files (*.qctools.xml *.qctools.xml.gz *.xml.gz *.xml)", 0, QFileDialog::DontUseNativeDialog);
+    QString FileName=QFileDialog::getSaveFileName(this, "Export to .qctools.xml.gz", Files[getFilesCurrentPos()]->fileName() + ".qctools.xml.gz", "Statistic files (*.qctools.xml *.qctools.xml.gz *.xml.gz *.xml)", 0);
     if (FileName.size()==0)
         return;
 
@@ -288,7 +288,7 @@ void MainWindow::on_actionExport_Mkv_Prompt_triggered()
     if (getFilesCurrentPos()>=Files.size() || !Files[getFilesCurrentPos()])
         return;
 
-    QString FileName=QFileDialog::getSaveFileName(this, "Export to .qctools.mkv", Files[getFilesCurrentPos()]->fileName() + ".qctools.mkv", "Statistic files (*.qctools.mkv)", 0, QFileDialog::DontUseNativeDialog);
+    QString FileName=QFileDialog::getSaveFileName(this, "Export to .qctools.mkv", Files[getFilesCurrentPos()]->fileName() + ".qctools.mkv", "Statistic files (*.qctools.mkv)", 0);
     if (FileName.size()==0)
         return;
 

--- a/Source/GUI/mainwindow_More.cpp
+++ b/Source/GUI/mainwindow_More.cpp
@@ -40,19 +40,11 @@
 //---------------------------------------------------------------------------
 void MainWindow::openFile()
 {
-    QFileDialog::Option options = QFileDialog::Option(0);
-
-#if defined(Q_OS_WIN) || defined(Q_OS_MACX)
-    // for Windows and Mac (to resolve 'gray-out files' issue (https://github.com/bavc/qctools/issues/293) use the Qt builtin dialog which displays files,
-    // other platforms should use the native dialog.
-    options = QFileDialog::DontUseNativeDialog;
-#endif
-
     QStringList List=QFileDialog::getOpenFileNames(this, "Open file", "", "All (*.*);;\
                                                                            Audio files (*.wav);;\
                                                                            Statistic files (*.qctools.xml *.qctools.xml.gz *.xml.gz *.xml);;\
                                                                            Statistic files with thumbnails (*.qctools.mkv);;\
-                                                                           Video files (*.avi *.mkv *.mov *.mxf *.mp4 *.ts *.m2ts)", 0, options);
+                                                                           Video files (*.avi *.mkv *.mov *.mxf *.mp4 *.ts *.m2ts)", 0);
     if (List.empty())
         return;
 

--- a/Source/GUI/mainwindow_Ui.cpp
+++ b/Source/GUI/mainwindow_Ui.cpp
@@ -524,7 +524,7 @@ void MainWindow::Export_PDF()
     if (getFilesCurrentPos()>=Files.size() || !Files[getFilesCurrentPos()])
         return;
 
-    QString SaveFileName=QFileDialog::getSaveFileName(this, "Acrobat Reader file (PDF)", Files[getFilesCurrentPos()]->fileName() + ".qctools.pdf", "PDF (*.pdf)", 0, QFileDialog::DontUseNativeDialog);
+    QString SaveFileName=QFileDialog::getSaveFileName(this, "Acrobat Reader file (PDF)", Files[getFilesCurrentPos()]->fileName() + ".qctools.pdf", "PDF (*.pdf)", 0);
 
     if (SaveFileName.isEmpty())
         return;


### PR DESCRIPTION
Qt file dialogs can't access external drives on newers macOS version.