### PR TITLE
QCli: Fix crash with mkv attachments

### DIFF
--- a/Source/Core/FileInformation.cpp
+++ b/Source/Core/FileInformation.cpp
@@ -951,7 +951,8 @@ FileInformation::FileInformation (SignalServer* signalServer, const QString &Fil
                         ++AudioPos;
                     }
 
-                    Stats.push_back(Stat);
+                    if (Stat)
+                        Stats.push_back(Stat);
                 }
 
                 streamsStats = new StreamsStats(orderedStreams, FormatContext);


### PR DESCRIPTION
Snapshot: https://mediaarea.net/download/snapshots/binary/qcli/20240901/