### PR TITLE
Fix build with FFmpeg 7

### DIFF
--- a/Source/Core/AudioStats.cpp
+++ b/Source/Core/AudioStats.cpp
@@ -13,6 +13,7 @@
 extern "C"
 {
 #include <libavutil/frame.h>
+#include <libavutil/version.h>
 #include <libavformat/avformat.h>
 }
 #include <qavplayer.h>
@@ -296,8 +297,13 @@ void AudioStats::TimeStampFromFrame (const QAVFrame& frame, size_t FramePos)
         x[2][FramePos]=x[1][FramePos]/60;
         x[3][FramePos]=x[2][FramePos]/60;
     }
+#if LIBAVUTIL_VERSION_INT <= AV_VERSION_INT(57, 30, 0)
     if (Frame->pkt_duration != AV_NOPTS_VALUE)
         durations[FramePos]=((double)Frame->pkt_duration)/Frequency;
+#else
+    if (Frame->duration != AV_NOPTS_VALUE)
+        durations[FramePos]=((double)Frame->duration)/Frequency;
+#endif
 }
 
 //---------------------------------------------------------------------------

--- a/Source/Core/FileInformation.cpp
+++ b/Source/Core/FileInformation.cpp
@@ -29,6 +29,7 @@ extern "C" {
 #include <libavutil/pixfmt.h>
 #include <libavutil/imgutils.h>
 #include <libavutil/ffversion.h>
+#include <libavutil/version.h>
 
 #ifndef WITH_SYSTEM_FFMPEG
 #include <config.h>
@@ -1580,7 +1581,11 @@ struct Output {
             return outPacket;
         }
 
+#if LIBAVUTIL_VERSION_INT <= AV_VERSION_INT(57, 30, 0)
         outPacket->duration = Frame->pkt_duration;
+#else
+        outPacket->duration = Frame->duration;
+#endif
         return outPacket;
     }
 };
@@ -2142,7 +2147,11 @@ std::string FileInformation::channelLayout() const
     if (stream.codec()->codec()->long_name == nullptr)
         return std::string();
 
+#if LIBAVUTIL_VERSION_INT <= AV_VERSION_INT(57, 23, 0)
     switch (stream.stream()->codecpar->channel_layout)
+#else
+    switch (stream.stream()->codecpar->ch_layout.u.mask)
+#endif
     {
     case AV_CH_LAYOUT_MONO: return "mono";
     case AV_CH_LAYOUT_STEREO: return "stereo";

--- a/Source/Core/VideoStats.cpp
+++ b/Source/Core/VideoStats.cpp
@@ -14,6 +14,7 @@ extern "C"
 {
 #include <libavutil/frame.h>
 #include <libavutil/pixdesc.h>
+#include <libavutil/version.h>
 }
 #include <qavplayer.h>
 
@@ -411,8 +412,13 @@ void VideoStats::TimeStampFromFrame (const QAVFrame& frame, size_t FramePos)
         x[2][FramePos]=x[1][FramePos]/60;
         x[3][FramePos]=x[2][FramePos]/60;
     }
+#if LIBAVUTIL_VERSION_INT <= AV_VERSION_INT(57, 30, 0)
     if (Frame->pkt_duration!=AV_NOPTS_VALUE)
         durations[FramePos]=((double)Frame->pkt_duration)/Frequency;
+#else
+    if (Frame->duration!=AV_NOPTS_VALUE)
+        durations[FramePos]=((double)Frame->duration)/Frequency;
+#endif
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
Conditionals for FFmpeg 7
* `pkt_duration` - https://github.com/FFmpeg/FFmpeg/commit/4397f9a5a09d82846bf787295c60f1104cf7de9e / https://github.com/FFmpeg/FFmpeg/commit/b8fef7e9c520b3923b32813b6a82c154c74402dc
* `channels` - https://github.com/FFmpeg/FFmpeg/commit/086a8048061bf9fb4c63943f6962db48175f655c / https://github.com/FFmpeg/FFmpeg/commit/65ddc74988245a01421a63c5cffa4d900c47117c

Versions ranges chosen based on submodule:
* https://github.com/valbok/QtAVPlayer/blob/master/src/QtAVPlayer/qavaudioconverter.cpp
* https://github.com/valbok/QtAVPlayer/blob/master/src/QtAVPlayer/qavframe.cpp

---

Only verified that it builds and app runs. Not sure if there is a test suite to verify it works as expected.

FFmpeg 8 would need more work as libpostproc is removed along with other deprecated APIs.